### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,9 +30,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: ^11.0
           - laravel: 12.*
             testbench: ^10.6
           - laravel: 11.*
@@ -40,6 +42,8 @@ jobs:
         exclude:
           - php: 8.5
             stability: prefer-lowest
+          - php: 8.3
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -82,13 +86,18 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: ^11.0
           - laravel: 12.*
             testbench: ^10.6
           - laravel: 11.*
             testbench: ^9.14
+        exclude:
+          - php: 8.3
+            laravel: 13.*
 
     name: Redis Integration - P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Extensible architecture with events for reactive monitoring and notifications.
 ## Requirements
 
 - PHP 8.3+
-- Laravel 11.0+ or 12.0+
+- Laravel 11.0, 12.0, or 13.0+
 - Redis or Database for metrics storage
 
 **Note**: Laravel 12.19+ is recommended for most accurate queue metrics ([Laravel PR #56010](https://github.com/laravel/framework/pull/56010)). Earlier versions use driver-specific implementations.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.3|^8.4|^8.5",
         "cboxdk/system-metrics": "^2.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16",
         "spatie/laravel-prometheus": "^1.3"
     },
@@ -31,7 +31,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ Get Laravel Queue Metrics up and running in your Laravel application.
 ## Requirements
 
 - **PHP**: 8.3 or higher
-- **Laravel**: 11.0+ or 12.0+
+- **Laravel**: 11.0, 12.0, or 13.0+
 - **Storage**: Redis (recommended) or Database
 - **Optional**: [cboxdk/system-metrics](https://github.com/cboxdk/system-metrics) for server monitoring
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -79,7 +79,7 @@ Deep dive into advanced capabilities:
 ## Package Requirements
 
 - **PHP**: 8.3 or higher
-- **Laravel**: 11.0 or higher (12.0+ recommended)
+- **Laravel**: 11.0 or higher (12.0+ recommended, 13.0 supported)
 - **Storage**: Redis (recommended) or Database
 
 ## License

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ Get up and running with Laravel Queue Metrics in 5 minutes.
 
 ## Prerequisites
 
-✅ Laravel 11.0+ or 12.0+ installed
+✅ Laravel 11.0, 12.0, or 13.0+ installed
 ✅ Redis or database configured
 ✅ Queue worker running
 


### PR DESCRIPTION
## Summary
- Add `orchestra/testbench ^11.0` for Laravel 13 testing
- Add Laravel 13 to CI matrix (unit + Redis integration tests)
- Exclude PHP 8.3 from Laravel 13 combinations (requires 8.4+)
- Update version references in README and docs

## Test plan
- [ ] CI passes for Laravel 11, 12, and 13 matrix
- [ ] Redis integration tests pass across all versions
- [ ] PHPStan passes
- [ ] Pint passes