### PR TITLE
feat: add JobMetricsFailed event and fix ProcessMetrics leak

### DIFF
--- a/docs/advanced-usage/events.md
+++ b/docs/advanced-usage/events.md
@@ -73,6 +73,74 @@ $event->metrics->throughput;        // ThroughputStatsDTO
 $event->metrics->lastFailure;       // ?FailureInfoDTO
 ```
 
+### JobMetricsCompleted
+
+**Dispatched**: When a job completes successfully with process-level metrics
+**Frequency**: High (every successful job)
+**Purpose**: Per-job metrics for downstream consumers (e.g., [Queue Monitor](https://github.com/cboxdk/laravel-queue-monitor))
+
+```php
+use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
+
+Event::listen(JobMetricsCompleted::class, function (JobMetricsCompleted $event) {
+    Log::info('Job completed', [
+        'job_id' => $event->jobId,
+        'job_class' => $event->jobClass,
+        'duration_ms' => $event->durationMs,
+        'memory_mb' => $event->memoryMb,
+        'cpu_time_ms' => $event->cpuTimeMs,
+    ]);
+});
+```
+
+**Available data:**
+
+```php
+$event->jobId;       // string
+$event->jobClass;    // string
+$event->connection;  // string
+$event->queue;       // string
+$event->durationMs;  // float
+$event->memoryMb;    // float
+$event->cpuTimeMs;   // float
+$event->hostname;    // ?string
+```
+
+### JobMetricsFailed
+
+**Dispatched**: When a job fails with process-level metrics
+**Frequency**: Low (only on failures)
+**Purpose**: Per-job failure metrics for downstream consumers (e.g., [Queue Monitor](https://github.com/cboxdk/laravel-queue-monitor))
+
+```php
+use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
+
+Event::listen(JobMetricsFailed::class, function (JobMetricsFailed $event) {
+    Log::error('Job failed', [
+        'job_id' => $event->jobId,
+        'job_class' => $event->jobClass,
+        'duration_ms' => $event->durationMs,
+        'memory_mb' => $event->memoryMb,
+        'cpu_time_ms' => $event->cpuTimeMs,
+        'exception' => $event->exceptionMessage,
+    ]);
+});
+```
+
+**Available data:**
+
+```php
+$event->jobId;             // string
+$event->jobClass;          // string
+$event->connection;        // string
+$event->queue;             // string
+$event->durationMs;        // float
+$event->memoryMb;          // float
+$event->cpuTimeMs;         // float
+$event->exceptionMessage;  // string
+$event->hostname;          // ?string
+```
+
 ### WorkerEfficiencyChanged
 
 **Dispatched**: When worker efficiency changes significantly
@@ -267,6 +335,8 @@ Register listeners in `app/Providers/EventServiceProvider.php`:
 ```php
 use Cbox\LaravelQueueMetrics\Events\{
     MetricsRecorded,
+    JobMetricsCompleted,
+    JobMetricsFailed,
     WorkerEfficiencyChanged,
     HealthScoreChanged,
     BaselineRecalculated,
@@ -277,6 +347,15 @@ protected $listen = [
     MetricsRecorded::class => [
         SendMetricsToDatadog::class,
         UpdateRealtimeDashboard::class,
+    ],
+
+    JobMetricsCompleted::class => [
+        RecordJobCompletionToMonitor::class,
+    ],
+
+    JobMetricsFailed::class => [
+        RecordJobFailureToMonitor::class,
+        AlertOnJobFailure::class,
     ],
 
     WorkerEfficiencyChanged::class => [

--- a/src/Events/JobMetricsCompleted.php
+++ b/src/Events/JobMetricsCompleted.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired per job when metrics are captured at job completion.
+ * Provides per-job CPU time, memory, and duration from process-level instrumentation.
+ */
+final class JobMetricsCompleted
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $jobId,
+        public readonly string $jobClass,
+        public readonly string $connection,
+        public readonly string $queue,
+        public readonly float $durationMs,
+        public readonly float $memoryMb,
+        public readonly float $cpuTimeMs,
+        public readonly ?string $hostname = null,
+    ) {}
+}

--- a/src/Events/JobMetricsFailed.php
+++ b/src/Events/JobMetricsFailed.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired per job when metrics are captured at job failure.
+ * Provides per-job CPU time, memory, duration, and exception from process-level instrumentation.
+ */
+final class JobMetricsFailed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $jobId,
+        public readonly string $jobClass,
+        public readonly string $connection,
+        public readonly string $queue,
+        public readonly float $durationMs,
+        public readonly float $memoryMb,
+        public readonly float $cpuTimeMs,
+        public readonly string $exceptionMessage,
+        public readonly ?string $hostname = null,
+    ) {}
+}

--- a/src/Listeners/JobFailedListener.php
+++ b/src/Listeners/JobFailedListener.php
@@ -7,7 +7,9 @@ namespace Cbox\LaravelQueueMetrics\Listeners;
 use Cbox\LaravelQueueMetrics\Actions\RecordJobFailureAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
+use Cbox\SystemMetrics\ProcessMetrics;
 use Illuminate\Queue\Events\JobFailed;
 
 /**
@@ -24,18 +26,56 @@ final readonly class JobFailedListener
     {
         $job = $event->job;
         $payload = $job->payload();
+        $jobId = (string) $job->getJobId();
+
+        // Calculate duration
+        $startTime = $payload['pushedAt'] ?? microtime(true);
+        $durationMs = (microtime(true) - $startTime) * 1000;
+
+        // Stop process metrics tracker (started in JobProcessingListener)
+        $trackerId = "job_{$jobId}";
+        $metricsResult = ProcessMetrics::stop($trackerId);
+
+        $memoryMb = memory_get_peak_usage(true) / 1024 / 1024;
+        $cpuTimeMs = 0.0;
+
+        if ($metricsResult->isSuccess()) {
+            $metrics = $metricsResult->getValue();
+
+            $memoryMb = $metrics->peak->memoryRssBytes / 1024 / 1024;
+
+            $cpuUsagePercent = $metrics->delta->cpuUsagePercentage();
+            $durationSeconds = $metrics->delta->durationSeconds;
+            $cpuTimeMs = ($cpuUsagePercent / 100.0) * $durationSeconds * 1000.0;
+        }
 
         $connection = $event->connectionName;
         $queue = $job->getQueue();
         $hostname = gethostname() ?: 'unknown';
+        $jobClass = $payload['displayName'] ?? 'UnknownJob';
 
         $this->recordJobFailure->execute(
-            jobId: (string) $job->getJobId(),
-            jobClass: $payload['displayName'] ?? 'UnknownJob',
+            jobId: $jobId,
+            jobClass: $jobClass,
             connection: $connection,
             queue: $queue,
             exception: $event->exception,
             hostname: $hostname,
+        );
+
+        // Fire per-job metrics event for downstream consumers (e.g., queue-monitor)
+        $exceptionMessage = $event->exception->getMessage().' in '.$event->exception->getFile().':'.$event->exception->getLine();
+
+        JobMetricsFailed::dispatch(
+            $jobId,
+            $jobClass,
+            $connection,
+            $queue,
+            $durationMs,
+            $memoryMb,
+            $cpuTimeMs,
+            $exceptionMessage,
+            $hostname,
         );
 
         // Record worker heartbeat with IDLE state (job failed, worker ready for next job)

--- a/src/Listeners/JobProcessedListener.php
+++ b/src/Listeners/JobProcessedListener.php
@@ -7,6 +7,7 @@ namespace Cbox\LaravelQueueMetrics\Listeners;
 use Cbox\LaravelQueueMetrics\Actions\RecordJobCompletionAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
 use Cbox\SystemMetrics\ProcessMetrics;
 use Illuminate\Queue\Events\JobProcessed;
@@ -56,15 +57,29 @@ final readonly class JobProcessedListener
         $queue = $job->getQueue();
         $hostname = gethostname() ?: 'unknown';
 
+        $jobClass = $payload['displayName'] ?? 'UnknownJob';
+
         $this->recordJobCompletion->execute(
             jobId: $jobId,
-            jobClass: $payload['displayName'] ?? 'UnknownJob',
+            jobClass: $jobClass,
             connection: $connection,
             queue: $queue,
             durationMs: $durationMs,
             memoryMb: $memoryMb,
             cpuTimeMs: $cpuTimeMs,
             hostname: $hostname,
+        );
+
+        // Fire per-job metrics event for downstream consumers (e.g., queue-monitor)
+        JobMetricsCompleted::dispatch(
+            $jobId,
+            $jobClass,
+            $connection,
+            $queue,
+            $durationMs,
+            $memoryMb,
+            $cpuTimeMs,
+            $hostname,
         );
 
         // Record worker heartbeat with IDLE state (job completed)

--- a/tests/Unit/Events/JobMetricsCompletedTest.php
+++ b/tests/Unit/Events/JobMetricsCompletedTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake([JobMetricsCompleted::class]);
+});
+
+it('can be dispatched with job completion metrics', function () {
+    JobMetricsCompleted::dispatch(
+        'job-123',
+        'App\Jobs\ProcessOrder',
+        'redis',
+        'default',
+        150.5,
+        25.3,
+        12.4,
+        'worker-01',
+    );
+
+    Event::assertDispatched(JobMetricsCompleted::class, function ($event) {
+        return $event->jobId === 'job-123'
+            && $event->jobClass === 'App\Jobs\ProcessOrder'
+            && $event->connection === 'redis'
+            && $event->queue === 'default'
+            && $event->durationMs === 150.5
+            && $event->memoryMb === 25.3
+            && $event->cpuTimeMs === 12.4
+            && $event->hostname === 'worker-01';
+    });
+})->group('functional');
+
+it('contains all per-job metrics data', function () {
+    $event = new JobMetricsCompleted(
+        jobId: 'job-456',
+        jobClass: 'App\Jobs\SendEmail',
+        connection: 'sqs',
+        queue: 'emails',
+        durationMs: 200.0,
+        memoryMb: 32.5,
+        cpuTimeMs: 18.7,
+        hostname: 'worker-02',
+    );
+
+    expect($event->jobId)->toBe('job-456')
+        ->and($event->jobClass)->toBe('App\Jobs\SendEmail')
+        ->and($event->connection)->toBe('sqs')
+        ->and($event->queue)->toBe('emails')
+        ->and($event->durationMs)->toBe(200.0)
+        ->and($event->memoryMb)->toBe(32.5)
+        ->and($event->cpuTimeMs)->toBe(18.7)
+        ->and($event->hostname)->toBe('worker-02');
+})->group('functional');
+
+it('allows null hostname', function () {
+    $event = new JobMetricsCompleted(
+        jobId: 'job-789',
+        jobClass: 'App\Jobs\TestJob',
+        connection: 'redis',
+        queue: 'default',
+        durationMs: 100.0,
+        memoryMb: 10.0,
+        cpuTimeMs: 5.0,
+    );
+
+    expect($event->hostname)->toBeNull();
+})->group('functional');
+
+it('is dispatchable using trait', function () {
+    expect(class_uses(JobMetricsCompleted::class))
+        ->toContain('Illuminate\Foundation\Events\Dispatchable');
+})->group('functional');

--- a/tests/Unit/Events/JobMetricsFailedTest.php
+++ b/tests/Unit/Events/JobMetricsFailedTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake([JobMetricsFailed::class]);
+});
+
+it('can be dispatched with job failure metrics', function () {
+    JobMetricsFailed::dispatch(
+        'job-123',
+        'App\Jobs\ProcessOrder',
+        'redis',
+        'default',
+        150.5,
+        25.3,
+        12.4,
+        'Division by zero in App/Jobs/ProcessOrder.php:42',
+        'worker-01',
+    );
+
+    Event::assertDispatched(JobMetricsFailed::class, function ($event) {
+        return $event->jobId === 'job-123'
+            && $event->jobClass === 'App\Jobs\ProcessOrder'
+            && $event->connection === 'redis'
+            && $event->queue === 'default'
+            && $event->durationMs === 150.5
+            && $event->memoryMb === 25.3
+            && $event->cpuTimeMs === 12.4
+            && $event->exceptionMessage === 'Division by zero in App/Jobs/ProcessOrder.php:42'
+            && $event->hostname === 'worker-01';
+    });
+})->group('functional');
+
+it('contains all per-job failure metrics data', function () {
+    $event = new JobMetricsFailed(
+        jobId: 'job-456',
+        jobClass: 'App\Jobs\SendEmail',
+        connection: 'sqs',
+        queue: 'emails',
+        durationMs: 200.0,
+        memoryMb: 32.5,
+        cpuTimeMs: 18.7,
+        exceptionMessage: 'Connection refused in App/Services/Mailer.php:15',
+        hostname: 'worker-02',
+    );
+
+    expect($event->jobId)->toBe('job-456')
+        ->and($event->jobClass)->toBe('App\Jobs\SendEmail')
+        ->and($event->connection)->toBe('sqs')
+        ->and($event->queue)->toBe('emails')
+        ->and($event->durationMs)->toBe(200.0)
+        ->and($event->memoryMb)->toBe(32.5)
+        ->and($event->cpuTimeMs)->toBe(18.7)
+        ->and($event->exceptionMessage)->toBe('Connection refused in App/Services/Mailer.php:15')
+        ->and($event->hostname)->toBe('worker-02');
+})->group('functional');
+
+it('allows null hostname', function () {
+    $event = new JobMetricsFailed(
+        jobId: 'job-789',
+        jobClass: 'App\Jobs\TestJob',
+        connection: 'redis',
+        queue: 'default',
+        durationMs: 100.0,
+        memoryMb: 10.0,
+        cpuTimeMs: 5.0,
+        exceptionMessage: 'Test exception',
+    );
+
+    expect($event->hostname)->toBeNull();
+})->group('functional');
+
+it('is dispatchable using trait', function () {
+    expect(class_uses(JobMetricsFailed::class))
+        ->toContain('Illuminate\Foundation\Events\Dispatchable');
+})->group('functional');


### PR DESCRIPTION
## Summary
- Add `JobMetricsFailed` event dispatched from `JobFailedListener` with per-job metrics (duration, memory, CPU, exception) for downstream consumers like queue-monitor
- Add `JobMetricsCompleted` event (existed on disk but was never committed)
- Fix ProcessMetrics tracker leak: `ProcessMetrics::start()` was called in `JobProcessingListener` but `ProcessMetrics::stop()` was only called in `JobProcessedListener` -- failed jobs never stopped the tracker
- Fix pre-existing PHPStan errors: named args in `Dispatchable::dispatch()` calls replaced with positional args
- Add unit tests for both `JobMetricsCompleted` and `JobMetricsFailed`
- Document both events in `docs/advanced-usage/events.md`

## Test plan
- [ ] All CI checks pass (PHPStan, Pint, tests across L11/L12/L13)
- [ ] New event tests pass: `JobMetricsCompletedTest`, `JobMetricsFailedTest`
- [ ] PHPStan level 9 clean (0 errors, was 17 before fix)