### PR TITLE
refactor: extract MemoryLimitParser and fix PHPStan errors

### DIFF
--- a/docs/advanced-usage/events.md
+++ b/docs/advanced-usage/events.md
@@ -96,14 +96,15 @@ Event::listen(JobMetricsCompleted::class, function (JobMetricsCompleted $event) 
 **Available data:**
 
 ```php
-$event->jobId;       // string
-$event->jobClass;    // string
-$event->connection;  // string
-$event->queue;       // string
-$event->durationMs;  // float
-$event->memoryMb;    // float
-$event->cpuTimeMs;   // float
-$event->hostname;    // ?string
+$event->jobId;                 // string
+$event->jobClass;              // string
+$event->connection;            // string
+$event->queue;                 // string
+$event->durationMs;            // float
+$event->memoryMb;              // float
+$event->cpuTimeMs;             // float
+$event->hostname;              // ?string
+$event->workerMemoryLimitMb;   // ?float (PHP memory_limit in MB, null if unlimited)
 ```
 
 ### JobMetricsFailed
@@ -130,15 +131,16 @@ Event::listen(JobMetricsFailed::class, function (JobMetricsFailed $event) {
 **Available data:**
 
 ```php
-$event->jobId;             // string
-$event->jobClass;          // string
-$event->connection;        // string
-$event->queue;             // string
-$event->durationMs;        // float
-$event->memoryMb;          // float
-$event->cpuTimeMs;         // float
-$event->exceptionMessage;  // string
-$event->hostname;          // ?string
+$event->jobId;                 // string
+$event->jobClass;              // string
+$event->connection;            // string
+$event->queue;                 // string
+$event->durationMs;            // float
+$event->memoryMb;              // float
+$event->cpuTimeMs;             // float
+$event->exceptionMessage;      // string
+$event->hostname;              // ?string
+$event->workerMemoryLimitMb;   // ?float (PHP memory_limit in MB, null if unlimited)
 ```
 
 ### WorkerEfficiencyChanged

--- a/src/Listeners/JobFailedListener.php
+++ b/src/Listeners/JobFailedListener.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
 use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
+use Cbox\LaravelQueueMetrics\Utilities\MemoryLimitParser;
 use Cbox\SystemMetrics\ProcessMetrics;
 use Illuminate\Queue\Events\JobFailed;
 
@@ -76,7 +77,7 @@ final readonly class JobFailedListener
             $cpuTimeMs,
             $exceptionMessage,
             $hostname,
-            self::getWorkerMemoryLimitMb(),
+            MemoryLimitParser::getCurrentLimitMb(),
         );
 
         // Record worker heartbeat with IDLE state (job failed, worker ready for next job)
@@ -94,22 +95,5 @@ final readonly class JobFailedListener
     private function getWorkerId(): string
     {
         return HorizonDetector::generateWorkerId();
-    }
-
-    private static function getWorkerMemoryLimitMb(): ?float
-    {
-        $limit = ini_get('memory_limit');
-        if ($limit === false || $limit === '' || $limit === '-1') {
-            return null;
-        }
-
-        $value = (int) $limit;
-
-        return match (strtoupper(substr($limit, -1))) {
-            'G' => $value * 1024.0,
-            'M' => (float) $value,
-            'K' => $value / 1024.0,
-            default => $value / 1024.0 / 1024.0,
-        };
     }
 }

--- a/src/Listeners/JobProcessedListener.php
+++ b/src/Listeners/JobProcessedListener.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
 use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
+use Cbox\LaravelQueueMetrics\Utilities\MemoryLimitParser;
 use Cbox\SystemMetrics\ProcessMetrics;
 use Illuminate\Queue\Events\JobProcessed;
 
@@ -80,7 +81,7 @@ final readonly class JobProcessedListener
             $memoryMb,
             $cpuTimeMs,
             $hostname,
-            self::getWorkerMemoryLimitMb(),
+            MemoryLimitParser::getCurrentLimitMb(),
         );
 
         // Record worker heartbeat with IDLE state (job completed)
@@ -98,22 +99,5 @@ final readonly class JobProcessedListener
     private function getWorkerId(): string
     {
         return HorizonDetector::generateWorkerId();
-    }
-
-    private static function getWorkerMemoryLimitMb(): ?float
-    {
-        $limit = ini_get('memory_limit');
-        if ($limit === false || $limit === '' || $limit === '-1') {
-            return null;
-        }
-
-        $value = (int) $limit;
-
-        return match (strtoupper(substr($limit, -1))) {
-            'G' => $value * 1024.0,
-            'M' => (float) $value,
-            'K' => $value / 1024.0,
-            default => $value / 1024.0 / 1024.0,
-        };
     }
 }

--- a/src/Utilities/MemoryLimitParser.php
+++ b/src/Utilities/MemoryLimitParser.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Utilities;
+
+/**
+ * Parse PHP memory_limit into megabytes.
+ */
+final class MemoryLimitParser
+{
+    /**
+     * Get the current PHP memory_limit in megabytes.
+     *
+     * Returns null if memory is unlimited (-1) or empty.
+     */
+    public static function getCurrentLimitMb(): ?float
+    {
+        $limit = ini_get('memory_limit');
+        if ($limit === '' || $limit === '-1') {
+            return null;
+        }
+
+        return self::parseToMb($limit);
+    }
+
+    /**
+     * Parse a PHP memory shorthand value (e.g. "128M", "1G") to megabytes.
+     */
+    public static function parseToMb(string $value): float
+    {
+        $numericValue = (int) $value;
+
+        return match (strtoupper(substr($value, -1))) {
+            'G' => $numericValue * 1024.0,
+            'M' => (float) $numericValue,
+            'K' => $numericValue / 1024.0,
+            default => $numericValue / 1024.0 / 1024.0,
+        };
+    }
+}

--- a/tests/Unit/Events/JobMetricsCompletedTest.php
+++ b/tests/Unit/Events/JobMetricsCompletedTest.php
@@ -19,6 +19,7 @@ it('can be dispatched with job completion metrics', function () {
         25.3,
         12.4,
         'worker-01',
+        512.0,
     );
 
     Event::assertDispatched(JobMetricsCompleted::class, function ($event) {
@@ -29,7 +30,8 @@ it('can be dispatched with job completion metrics', function () {
             && $event->durationMs === 150.5
             && $event->memoryMb === 25.3
             && $event->cpuTimeMs === 12.4
-            && $event->hostname === 'worker-01';
+            && $event->hostname === 'worker-01'
+            && $event->workerMemoryLimitMb === 512.0;
     });
 })->group('functional');
 
@@ -43,6 +45,7 @@ it('contains all per-job metrics data', function () {
         memoryMb: 32.5,
         cpuTimeMs: 18.7,
         hostname: 'worker-02',
+        workerMemoryLimitMb: 1024.0,
     );
 
     expect($event->jobId)->toBe('job-456')
@@ -52,10 +55,11 @@ it('contains all per-job metrics data', function () {
         ->and($event->durationMs)->toBe(200.0)
         ->and($event->memoryMb)->toBe(32.5)
         ->and($event->cpuTimeMs)->toBe(18.7)
-        ->and($event->hostname)->toBe('worker-02');
+        ->and($event->hostname)->toBe('worker-02')
+        ->and($event->workerMemoryLimitMb)->toBe(1024.0);
 })->group('functional');
 
-it('allows null hostname', function () {
+it('allows null hostname and memory limit', function () {
     $event = new JobMetricsCompleted(
         jobId: 'job-789',
         jobClass: 'App\Jobs\TestJob',
@@ -66,7 +70,8 @@ it('allows null hostname', function () {
         cpuTimeMs: 5.0,
     );
 
-    expect($event->hostname)->toBeNull();
+    expect($event->hostname)->toBeNull()
+        ->and($event->workerMemoryLimitMb)->toBeNull();
 })->group('functional');
 
 it('is dispatchable using trait', function () {

--- a/tests/Unit/Events/JobMetricsFailedTest.php
+++ b/tests/Unit/Events/JobMetricsFailedTest.php
@@ -20,6 +20,7 @@ it('can be dispatched with job failure metrics', function () {
         12.4,
         'Division by zero in App/Jobs/ProcessOrder.php:42',
         'worker-01',
+        512.0,
     );
 
     Event::assertDispatched(JobMetricsFailed::class, function ($event) {
@@ -31,7 +32,8 @@ it('can be dispatched with job failure metrics', function () {
             && $event->memoryMb === 25.3
             && $event->cpuTimeMs === 12.4
             && $event->exceptionMessage === 'Division by zero in App/Jobs/ProcessOrder.php:42'
-            && $event->hostname === 'worker-01';
+            && $event->hostname === 'worker-01'
+            && $event->workerMemoryLimitMb === 512.0;
     });
 })->group('functional');
 
@@ -46,6 +48,7 @@ it('contains all per-job failure metrics data', function () {
         cpuTimeMs: 18.7,
         exceptionMessage: 'Connection refused in App/Services/Mailer.php:15',
         hostname: 'worker-02',
+        workerMemoryLimitMb: 256.0,
     );
 
     expect($event->jobId)->toBe('job-456')
@@ -56,10 +59,11 @@ it('contains all per-job failure metrics data', function () {
         ->and($event->memoryMb)->toBe(32.5)
         ->and($event->cpuTimeMs)->toBe(18.7)
         ->and($event->exceptionMessage)->toBe('Connection refused in App/Services/Mailer.php:15')
-        ->and($event->hostname)->toBe('worker-02');
+        ->and($event->hostname)->toBe('worker-02')
+        ->and($event->workerMemoryLimitMb)->toBe(256.0);
 })->group('functional');
 
-it('allows null hostname', function () {
+it('allows null hostname and memory limit', function () {
     $event = new JobMetricsFailed(
         jobId: 'job-789',
         jobClass: 'App\Jobs\TestJob',
@@ -71,7 +75,8 @@ it('allows null hostname', function () {
         exceptionMessage: 'Test exception',
     );
 
-    expect($event->hostname)->toBeNull();
+    expect($event->hostname)->toBeNull()
+        ->and($event->workerMemoryLimitMb)->toBeNull();
 })->group('functional');
 
 it('is dispatchable using trait', function () {

--- a/tests/Unit/Utilities/MemoryLimitParserTest.php
+++ b/tests/Unit/Utilities/MemoryLimitParserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Utilities\MemoryLimitParser;
+
+it('parses megabyte values', function () {
+    expect(MemoryLimitParser::parseToMb('128M'))->toBe(128.0)
+        ->and(MemoryLimitParser::parseToMb('256M'))->toBe(256.0)
+        ->and(MemoryLimitParser::parseToMb('512M'))->toBe(512.0);
+});
+
+it('parses gigabyte values', function () {
+    expect(MemoryLimitParser::parseToMb('1G'))->toBe(1024.0)
+        ->and(MemoryLimitParser::parseToMb('2G'))->toBe(2048.0);
+});
+
+it('parses kilobyte values', function () {
+    expect(MemoryLimitParser::parseToMb('1024K'))->toBe(1.0)
+        ->and(MemoryLimitParser::parseToMb('512K'))->toBe(0.5);
+});
+
+it('parses raw byte values', function () {
+    // 128 MB in bytes
+    expect(MemoryLimitParser::parseToMb('134217728'))->toBe(128.0);
+});
+
+it('handles lowercase suffixes', function () {
+    expect(MemoryLimitParser::parseToMb('128m'))->toBe(128.0)
+        ->and(MemoryLimitParser::parseToMb('1g'))->toBe(1024.0)
+        ->and(MemoryLimitParser::parseToMb('1024k'))->toBe(1.0);
+});
+
+it('returns current memory limit in megabytes', function () {
+    $originalLimit = ini_get('memory_limit');
+
+    ini_set('memory_limit', '256M');
+    expect(MemoryLimitParser::getCurrentLimitMb())->toBe(256.0);
+
+    ini_set('memory_limit', '1G');
+    expect(MemoryLimitParser::getCurrentLimitMb())->toBe(1024.0);
+
+    ini_set('memory_limit', $originalLimit);
+});
+
+it('returns null for unlimited memory', function () {
+    $originalLimit = ini_get('memory_limit');
+
+    ini_set('memory_limit', '-1');
+    expect(MemoryLimitParser::getCurrentLimitMb())->toBeNull();
+
+    ini_set('memory_limit', $originalLimit);
+});


### PR DESCRIPTION
## Summary
- Extract duplicated `getWorkerMemoryLimitMb()` from `JobProcessedListener` and `JobFailedListener` into shared `MemoryLimitParser` utility
- Fix 2 PHPStan level 9 errors: `ini_get('memory_limit')` never returns `false` for known settings
- Add comprehensive unit tests for `MemoryLimitParser` (M/G/K/bytes/lowercase/unlimited)
- Update event tests to cover `workerMemoryLimitMb` property
- Document `workerMemoryLimitMb` in events.md

## Test plan
- [ ] PHPStan level 9 clean (0 errors)
- [ ] Pint clean
- [ ] All tests pass across L11/L12/L13 matrix
- [ ] New `MemoryLimitParserTest` covers all shorthand formats