### PR TITLE
feat: add database storage driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,38 @@ Extensible architecture with events for reactive monitoring and notifications.
 
 ## Configuration
 
-### Storage Backend
+### Storage Drivers
 
-**Redis (Recommended for Production)**:
+#### Redis (default, recommended)
+
+Redis is the recommended driver for all workloads. It handles high-frequency metrics writes with minimal overhead.
 
 ```env
 QUEUE_METRICS_STORAGE=redis
 QUEUE_METRICS_CONNECTION=default
 ```
 
-**Database (For Persistence)**:
+#### Database
+
+For applications without Redis infrastructure, a database driver is available. This stores metrics in 4 database tables using the same schema as your application database.
 
 ```env
 QUEUE_METRICS_STORAGE=database
+QUEUE_METRICS_CONNECTION=mysql  # or your database connection
 ```
+
+Run the migration to create the metrics tables:
+
+```bash
+php artisan vendor:publish --tag="laravel-queue-metrics-migrations"
+php artisan migrate
+```
+
+> **Important:** The database driver is designed for low-scale workloads (< 10 workers). At higher scale, metrics writes create contention on the same database your queue jobs use. Use Redis for production with moderate to high workloads.
+
+> **Recommended setting for database driver:** Set `QUEUE_METRICS_MAX_SAMPLES=500` to keep table sizes manageable.
+
+The database cleanup command runs automatically every minute when using the database driver, removing expired data and trimming sample tables.
 
 ### API Authentication
 

--- a/config/queue-metrics.php
+++ b/config/queue-metrics.php
@@ -17,11 +17,6 @@ use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerRepository;
-use Cbox\LaravelQueueMetrics\Repositories\RedisBaselineRepository;
-use Cbox\LaravelQueueMetrics\Repositories\RedisJobMetricsRepository;
-use Cbox\LaravelQueueMetrics\Repositories\RedisQueueMetricsRepository;
-use Cbox\LaravelQueueMetrics\Repositories\RedisWorkerHeartbeatRepository;
-use Cbox\LaravelQueueMetrics\Repositories\RedisWorkerRepository;
 
 // config for Cbox/LaravelQueueMetrics
 return [
@@ -38,6 +33,11 @@ return [
         'driver' => env('QUEUE_METRICS_STORAGE', 'redis'),
         'connection' => env('QUEUE_METRICS_CONNECTION', 'default'),
         'prefix' => 'queue_metrics',
+
+        // Maximum retained samples per metric key.
+        // Recommended: 1000 for Redis, 500 for database driver.
+        'max_samples_per_key' => env('QUEUE_METRICS_MAX_SAMPLES', 1000),
+        'cleanup_chunk_size' => 1000,
 
         'ttl' => [
             'raw' => 3600,
@@ -105,11 +105,11 @@ return [
     */
 
     'repositories' => [
-        JobMetricsRepository::class => RedisJobMetricsRepository::class,
-        QueueMetricsRepository::class => RedisQueueMetricsRepository::class,
-        WorkerRepository::class => RedisWorkerRepository::class,
-        BaselineRepository::class => RedisBaselineRepository::class,
-        WorkerHeartbeatRepository::class => RedisWorkerHeartbeatRepository::class,
+        JobMetricsRepository::class => null,
+        QueueMetricsRepository::class => null,
+        WorkerRepository::class => null,
+        BaselineRepository::class => null,
+        WorkerHeartbeatRepository::class => null,
     ],
 
     'actions' => [

--- a/src/Config/StorageConfig.php
+++ b/src/Config/StorageConfig.php
@@ -38,8 +38,8 @@ final readonly class StorageConfig
             connection: is_string($config['connection'] ?? null) ? $config['connection'] : 'default',
             prefix: is_string($config['prefix'] ?? null) ? $config['prefix'] : 'queue_metrics',
             ttls: $ttls,
-            maxSamplesPerKey: (int) ($config['max_samples_per_key'] ?? 1000),
-            cleanupChunkSize: (int) ($config['cleanup_chunk_size'] ?? 1000),
+            maxSamplesPerKey: is_numeric($config['max_samples_per_key'] ?? null) ? (int) $config['max_samples_per_key'] : 1000,
+            cleanupChunkSize: is_numeric($config['cleanup_chunk_size'] ?? null) ? (int) $config['cleanup_chunk_size'] : 1000,
         );
     }
 

--- a/src/Config/StorageConfig.php
+++ b/src/Config/StorageConfig.php
@@ -17,6 +17,8 @@ final readonly class StorageConfig
         public string $connection,
         public string $prefix,
         public array $ttls,
+        public int $maxSamplesPerKey,
+        public int $cleanupChunkSize,
     ) {}
 
     /**
@@ -36,6 +38,8 @@ final readonly class StorageConfig
             connection: is_string($config['connection'] ?? null) ? $config['connection'] : 'default',
             prefix: is_string($config['prefix'] ?? null) ? $config['prefix'] : 'queue_metrics',
             ttls: $ttls,
+            maxSamplesPerKey: (int) ($config['max_samples_per_key'] ?? 1000),
+            cleanupChunkSize: (int) ($config['cleanup_chunk_size'] ?? 1000),
         );
     }
 

--- a/src/Console/CleanupDatabaseCommand.php
+++ b/src/Console/CleanupDatabaseCommand.php
@@ -17,27 +17,29 @@ class CleanupDatabaseCommand extends Command
 
     public function handle(): int
     {
-        $chunkSize = (int) config('queue-metrics.storage.cleanup_chunk_size', 1000);
+        $chunkSize = is_numeric($configChunk = config('queue-metrics.storage.cleanup_chunk_size', 1000)) ? (int) $configChunk : 1000;
 
         // Delete expired rows via subquery to support SQLite (no auto-increment id on all tables)
         MetricsKey::whereIn('key', MetricsKey::expired()->limit($chunkSize)->pluck('key'))->delete();
         MetricsHash::whereIn('key', MetricsHash::expired()->limit($chunkSize)->pluck('key'))->delete();
 
         // MetricsSortedSet has a composite unique key (key, member) — delete via member
-        MetricsSortedSet::expired()
+        /** @var \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<int, MetricsSortedSet>> $grouped */
+        $grouped = MetricsSortedSet::expired()
             ->orderBy('key')
             ->orderBy('member')
             ->limit($chunkSize)
-            ->get(['key', 'member'])
-            ->groupBy('key')
-            ->each(function ($rows, $key) {
-                MetricsSortedSet::where('key', $key)
-                    ->whereIn('member', $rows->pluck('member'))
-                    ->delete();
-            });
+            ->get()
+            ->groupBy('key');
+
+        $grouped->each(function ($rows, $key) {
+            MetricsSortedSet::where('key', (string) $key)
+                ->whereIn('member', $rows->pluck('member'))
+                ->delete();
+        });
 
         // Trim sorted sets exceeding max_samples_per_key
-        $maxSamples = (int) config('queue-metrics.storage.max_samples_per_key', 1000);
+        $maxSamples = is_numeric($configMax = config('queue-metrics.storage.max_samples_per_key', 1000)) ? (int) $configMax : 1000;
 
         $oversized = MetricsSortedSet::query()
             ->select('key')
@@ -47,12 +49,16 @@ class CleanupDatabaseCommand extends Command
             ->get();
 
         foreach ($oversized as $row) {
-            $excess = MetricsSortedSet::where('key', $row->key)
+            $rowKey = $row->key;
+            /** @var int $rowCnt */
+            $rowCnt = $row->getAttribute('cnt');
+
+            $excess = MetricsSortedSet::where('key', $rowKey)
                 ->orderBy('score')
-                ->limit($row->cnt - $maxSamples)
+                ->limit($rowCnt - $maxSamples)
                 ->pluck('member');
 
-            MetricsSortedSet::where('key', $row->key)
+            MetricsSortedSet::where('key', $rowKey)
                 ->whereIn('member', $excess)
                 ->delete();
         }

--- a/src/Console/CleanupDatabaseCommand.php
+++ b/src/Console/CleanupDatabaseCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Console;
+
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Models\MetricsKey;
+use Cbox\LaravelQueueMetrics\Models\MetricsSortedSet;
+use Illuminate\Console\Command;
+
+class CleanupDatabaseCommand extends Command
+{
+    public $signature = 'queue-metrics:cleanup-database';
+
+    public $description = 'Remove expired metrics data from database storage';
+
+    public function handle(): int
+    {
+        $chunkSize = (int) config('queue-metrics.storage.cleanup_chunk_size', 1000);
+
+        // Delete expired rows via subquery to support SQLite (no auto-increment id on all tables)
+        MetricsKey::whereIn('key', MetricsKey::expired()->limit($chunkSize)->pluck('key'))->delete();
+        MetricsHash::whereIn('key', MetricsHash::expired()->limit($chunkSize)->pluck('key'))->delete();
+
+        // MetricsSortedSet has a composite unique key (key, member) — delete via member
+        MetricsSortedSet::expired()
+            ->orderBy('key')
+            ->orderBy('member')
+            ->limit($chunkSize)
+            ->get(['key', 'member'])
+            ->groupBy('key')
+            ->each(function ($rows, $key) {
+                MetricsSortedSet::where('key', $key)
+                    ->whereIn('member', $rows->pluck('member'))
+                    ->delete();
+            });
+
+        // Trim sorted sets exceeding max_samples_per_key
+        $maxSamples = (int) config('queue-metrics.storage.max_samples_per_key', 1000);
+
+        $oversized = MetricsSortedSet::query()
+            ->select('key')
+            ->selectRaw('COUNT(*) as cnt')
+            ->groupBy('key')
+            ->havingRaw('COUNT(*) > ?', [$maxSamples])
+            ->get();
+
+        foreach ($oversized as $row) {
+            $excess = MetricsSortedSet::where('key', $row->key)
+                ->orderBy('score')
+                ->limit($row->cnt - $maxSamples)
+                ->pluck('member');
+
+            MetricsSortedSet::where('key', $row->key)
+                ->whereIn('member', $excess)
+                ->delete();
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/CleanupDatabaseCommand.php
+++ b/src/Console/CleanupDatabaseCommand.php
@@ -8,6 +8,7 @@ use Cbox\LaravelQueueMetrics\Models\MetricsHash;
 use Cbox\LaravelQueueMetrics\Models\MetricsKey;
 use Cbox\LaravelQueueMetrics\Models\MetricsSortedSet;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 
 class CleanupDatabaseCommand extends Command
 {
@@ -24,7 +25,7 @@ class CleanupDatabaseCommand extends Command
         MetricsHash::whereIn('key', MetricsHash::expired()->limit($chunkSize)->pluck('key'))->delete();
 
         // MetricsSortedSet has a composite unique key (key, member) — delete via member
-        /** @var \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<int, MetricsSortedSet>> $grouped */
+        /** @var Collection<string, Collection<int, MetricsSortedSet>> $grouped */
         $grouped = MetricsSortedSet::expired()
             ->orderBy('key')
             ->orderBy('member')

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -90,10 +90,15 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             return $app->make(QueueMetricsConfig::class)->storage;
         });
 
-        // Register Redis metrics store - uses Laravel's Redis connection directly
-        $this->app->singleton(RedisMetricsStore::class, function () {
-            return new RedisMetricsStore;
-        });
+        // Register the appropriate metrics store
+        $driver = config('queue-metrics.storage.driver', 'redis');
+        if ($driver === 'database') {
+            $this->app->singleton(\Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore::class);
+        } else {
+            $this->app->singleton(RedisMetricsStore::class, function () {
+                return new RedisMetricsStore;
+            });
+        }
 
         // Register repositories from config (extensible Spatie-style)
         $this->registerRepositoriesFromConfig();
@@ -119,19 +124,37 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
 
     /**
      * Register repositories from config - allows users to extend/replace repositories.
+     *
+     * When a repository config value is null, the implementation is resolved
+     * from the configured storage driver (redis or database).
      */
     protected function registerRepositoriesFromConfig(): void
     {
-        /** @var array<class-string, class-string> $repositories */
-        $repositories = config('queue-metrics.repositories', [
-            JobMetricsRepository::class => RedisJobMetricsRepository::class,
-            QueueMetricsRepository::class => RedisQueueMetricsRepository::class,
-            WorkerRepository::class => RedisWorkerRepository::class,
-            BaselineRepository::class => RedisBaselineRepository::class,
-            WorkerHeartbeatRepository::class => RedisWorkerHeartbeatRepository::class,
-        ]);
+        $driver = config('queue-metrics.storage.driver', 'redis');
 
-        foreach ($repositories as $contract => $implementation) {
+        /** @var array<class-string, class-string> */
+        $driverDefaults = match ($driver) {
+            'database' => [
+                JobMetricsRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository::class,
+                QueueMetricsRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository::class,
+                WorkerRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerRepository::class,
+                BaselineRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseBaselineRepository::class,
+                WorkerHeartbeatRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository::class,
+            ],
+            default => [
+                JobMetricsRepository::class => RedisJobMetricsRepository::class,
+                QueueMetricsRepository::class => RedisQueueMetricsRepository::class,
+                WorkerRepository::class => RedisWorkerRepository::class,
+                BaselineRepository::class => RedisBaselineRepository::class,
+                WorkerHeartbeatRepository::class => RedisWorkerHeartbeatRepository::class,
+            ],
+        };
+
+        /** @var array<class-string, class-string|null> $repositories */
+        $repositories = config('queue-metrics.repositories', []);
+
+        foreach ($driverDefaults as $contract => $default) {
+            $implementation = $repositories[$contract] ?? $default;
             $this->app->singleton($contract, $implementation);
         }
     }
@@ -222,6 +245,13 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             if (config('queue-metrics.scheduling.tasks.record_trends', true)) {
                 // Schedule trend data recording (every minute for real-time trends)
                 $scheduler->command('queue-metrics:record-trends')
+                    ->everyMinute()
+                    ->withoutOverlapping();
+            }
+
+            // Schedule database cleanup when using database driver
+            if (config('queue-metrics.storage.driver') === 'database') {
+                $scheduler->command('queue-metrics:cleanup-database')
                     ->everyMinute()
                     ->withoutOverlapping();
             }

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -34,6 +34,11 @@ use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseBaselineRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerRepository;
 use Cbox\LaravelQueueMetrics\Repositories\RedisBaselineRepository;
 use Cbox\LaravelQueueMetrics\Repositories\RedisJobMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\RedisQueueMetricsRepository;
@@ -46,6 +51,7 @@ use Cbox\LaravelQueueMetrics\Services\QueueMetricsQueryService;
 use Cbox\LaravelQueueMetrics\Services\RedisKeyScannerService;
 use Cbox\LaravelQueueMetrics\Services\ServerMetricsService;
 use Cbox\LaravelQueueMetrics\Services\WorkerMetricsQueryService;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
 use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
 use Cbox\LaravelQueueMetrics\Utilities\PercentileCalculator;
 use Illuminate\Console\Scheduling\Schedule;
@@ -93,7 +99,7 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
         // Register the appropriate metrics store
         $driver = config('queue-metrics.storage.driver', 'redis');
         if ($driver === 'database') {
-            $this->app->singleton(\Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore::class);
+            $this->app->singleton(DatabaseMetricsStore::class);
         } else {
             $this->app->singleton(RedisMetricsStore::class, function () {
                 return new RedisMetricsStore;
@@ -134,11 +140,11 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
 
         $driverDefaults = match ($driver) {
             'database' => [
-                JobMetricsRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository::class,
-                QueueMetricsRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository::class,
-                WorkerRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerRepository::class,
-                BaselineRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseBaselineRepository::class,
-                WorkerHeartbeatRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository::class,
+                JobMetricsRepository::class => DatabaseJobMetricsRepository::class,
+                QueueMetricsRepository::class => DatabaseQueueMetricsRepository::class,
+                WorkerRepository::class => DatabaseWorkerRepository::class,
+                BaselineRepository::class => DatabaseBaselineRepository::class,
+                WorkerHeartbeatRepository::class => DatabaseWorkerHeartbeatRepository::class,
             ],
             default => [
                 JobMetricsRepository::class => RedisJobMetricsRepository::class,

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -15,6 +15,7 @@ use Cbox\LaravelQueueMetrics\Commands\CleanupStaleWorkersCommand;
 use Cbox\LaravelQueueMetrics\Config\QueueMetricsConfig;
 use Cbox\LaravelQueueMetrics\Config\StorageConfig;
 use Cbox\LaravelQueueMetrics\Console\CalculateQueueMetricsCommand;
+use Cbox\LaravelQueueMetrics\Console\CleanupDatabaseCommand;
 use Cbox\LaravelQueueMetrics\Console\DetectStaleWorkersCommand;
 use Cbox\LaravelQueueMetrics\Console\RecordTrendDataCommand;
 use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
@@ -72,6 +73,7 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             ->hasMigration('2024_01_01_000001_create_queue_metrics_storage_tables')
             ->hasCommand(CalculateBaselinesCommand::class)
             ->hasCommand(CalculateQueueMetricsCommand::class)
+            ->hasCommand(CleanupDatabaseCommand::class)
             ->hasCommand(CleanupStaleWorkersCommand::class)
             ->hasCommand(DetectStaleWorkersCommand::class)
             ->hasCommand(RecordTrendDataCommand::class);

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -132,7 +132,6 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
     {
         $driver = config('queue-metrics.storage.driver', 'redis');
 
-        /** @var array<class-string, class-string> */
         $driverDefaults = match ($driver) {
             'database' => [
                 JobMetricsRepository::class => \Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository::class,

--- a/src/Models/MetricsHash.php
+++ b/src/Models/MetricsHash.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMetrics\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property string $key
+ * @property array<string, mixed> $data
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
 class MetricsHash extends Model
 {
     public $timestamps = false;
@@ -29,7 +36,7 @@ class MetricsHash extends Model
 
     public function getTable(): string
     {
-        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+        $prefix = is_string($raw = config('queue-metrics.storage.prefix', 'queue_metrics')) ? $raw : 'queue_metrics';
 
         return $prefix.'_hashes';
     }
@@ -41,14 +48,22 @@ class MetricsHash extends Model
         return is_string($connection) ? $connection : parent::getConnectionName();
     }
 
-    public function scopeNotExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeNotExpired(Builder $query): Builder
     {
-        return $query->where(function ($q) {
+        return $query->where(function (Builder $q) {
             $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
         });
     }
 
-    public function scopeExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeExpired(Builder $query): Builder
     {
         return $query->where('expires_at', '<', now());
     }

--- a/src/Models/MetricsHash.php
+++ b/src/Models/MetricsHash.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MetricsHash extends Model
+{
+    public $timestamps = false;
+
+    protected $primaryKey = 'key';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = ['key', 'data', 'expires_at', 'updated_at'];
+
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+            'expires_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    public function getTable(): string
+    {
+        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+
+        return $prefix.'_hashes';
+    }
+
+    public function getConnectionName(): ?string
+    {
+        $connection = config('queue-metrics.storage.connection');
+
+        return is_string($connection) ? $connection : parent::getConnectionName();
+    }
+
+    public function scopeNotExpired($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+
+    public function scopeExpired($query)
+    {
+        return $query->where('expires_at', '<', now());
+    }
+}

--- a/src/Models/MetricsHash.php
+++ b/src/Models/MetricsHash.php
@@ -6,12 +6,13 @@ namespace Cbox\LaravelQueueMetrics\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $key
  * @property array<string, mixed> $data
- * @property \Illuminate\Support\Carbon|null $expires_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $updated_at
  */
 class MetricsHash extends Model
 {

--- a/src/Models/MetricsKey.php
+++ b/src/Models/MetricsKey.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MetricsKey extends Model
+{
+    public $timestamps = false;
+
+    protected $primaryKey = 'key';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = ['key', 'value', 'expires_at', 'updated_at'];
+
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    public function getTable(): string
+    {
+        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+
+        return $prefix.'_keys';
+    }
+
+    public function getConnectionName(): ?string
+    {
+        $connection = config('queue-metrics.storage.connection');
+
+        return is_string($connection) ? $connection : parent::getConnectionName();
+    }
+
+    public function scopeNotExpired($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+
+    public function scopeExpired($query)
+    {
+        return $query->where('expires_at', '<', now());
+    }
+}

--- a/src/Models/MetricsKey.php
+++ b/src/Models/MetricsKey.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMetrics\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property string $key
+ * @property string|null $value
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
 class MetricsKey extends Model
 {
     public $timestamps = false;
@@ -28,7 +35,7 @@ class MetricsKey extends Model
 
     public function getTable(): string
     {
-        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+        $prefix = is_string($raw = config('queue-metrics.storage.prefix', 'queue_metrics')) ? $raw : 'queue_metrics';
 
         return $prefix.'_keys';
     }
@@ -40,14 +47,22 @@ class MetricsKey extends Model
         return is_string($connection) ? $connection : parent::getConnectionName();
     }
 
-    public function scopeNotExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeNotExpired(Builder $query): Builder
     {
-        return $query->where(function ($q) {
+        return $query->where(function (Builder $q) {
             $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
         });
     }
 
-    public function scopeExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeExpired(Builder $query): Builder
     {
         return $query->where('expires_at', '<', now());
     }

--- a/src/Models/MetricsKey.php
+++ b/src/Models/MetricsKey.php
@@ -6,12 +6,13 @@ namespace Cbox\LaravelQueueMetrics\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $key
  * @property string|null $value
- * @property \Illuminate\Support\Carbon|null $expires_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $updated_at
  */
 class MetricsKey extends Model
 {

--- a/src/Models/MetricsSet.php
+++ b/src/Models/MetricsSet.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MetricsSet extends Model
+{
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $fillable = ['key', 'member', 'created_at'];
+
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function getTable(): string
+    {
+        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+
+        return $prefix.'_sets';
+    }
+
+    public function getConnectionName(): ?string
+    {
+        $connection = config('queue-metrics.storage.connection');
+
+        return is_string($connection) ? $connection : parent::getConnectionName();
+    }
+}

--- a/src/Models/MetricsSet.php
+++ b/src/Models/MetricsSet.php
@@ -6,6 +6,11 @@ namespace Cbox\LaravelQueueMetrics\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property string $key
+ * @property string $member
+ * @property \Illuminate\Support\Carbon|null $created_at
+ */
 class MetricsSet extends Model
 {
     public $timestamps = false;
@@ -23,7 +28,7 @@ class MetricsSet extends Model
 
     public function getTable(): string
     {
-        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+        $prefix = is_string($raw = config('queue-metrics.storage.prefix', 'queue_metrics')) ? $raw : 'queue_metrics';
 
         return $prefix.'_sets';
     }

--- a/src/Models/MetricsSet.php
+++ b/src/Models/MetricsSet.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMetrics\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $key
  * @property string $member
- * @property \Illuminate\Support\Carbon|null $created_at
+ * @property Carbon|null $created_at
  */
 class MetricsSet extends Model
 {

--- a/src/Models/MetricsSortedSet.php
+++ b/src/Models/MetricsSortedSet.php
@@ -6,13 +6,14 @@ namespace Cbox\LaravelQueueMetrics\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $key
  * @property string $member
  * @property string $score
- * @property \Illuminate\Support\Carbon|null $expires_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $updated_at
  */
 class MetricsSortedSet extends Model
 {

--- a/src/Models/MetricsSortedSet.php
+++ b/src/Models/MetricsSortedSet.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMetrics\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property string $key
+ * @property string $member
+ * @property string $score
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
 class MetricsSortedSet extends Model
 {
     public $timestamps = false;
@@ -25,7 +33,7 @@ class MetricsSortedSet extends Model
 
     public function getTable(): string
     {
-        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+        $prefix = is_string($raw = config('queue-metrics.storage.prefix', 'queue_metrics')) ? $raw : 'queue_metrics';
 
         return $prefix.'_sorted_sets';
     }
@@ -37,14 +45,22 @@ class MetricsSortedSet extends Model
         return is_string($connection) ? $connection : parent::getConnectionName();
     }
 
-    public function scopeNotExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeNotExpired(Builder $query): Builder
     {
-        return $query->where(function ($q) {
+        return $query->where(function (Builder $q) {
             $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
         });
     }
 
-    public function scopeExpired($query)
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeExpired(Builder $query): Builder
     {
         return $query->where('expires_at', '<', now());
     }

--- a/src/Models/MetricsSortedSet.php
+++ b/src/Models/MetricsSortedSet.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MetricsSortedSet extends Model
+{
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $fillable = ['key', 'member', 'score', 'expires_at', 'updated_at'];
+
+    protected function casts(): array
+    {
+        return [
+            'score' => 'decimal:4',
+            'expires_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    public function getTable(): string
+    {
+        $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+
+        return $prefix.'_sorted_sets';
+    }
+
+    public function getConnectionName(): ?string
+    {
+        $connection = config('queue-metrics.storage.connection');
+
+        return is_string($connection) ? $connection : parent::getConnectionName();
+    }
+
+    public function scopeNotExpired($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+
+    public function scopeExpired($query)
+    {
+        return $query->where('expires_at', '<', now());
+    }
+}

--- a/src/Repositories/DatabaseBaselineRepository.php
+++ b/src/Repositories/DatabaseBaselineRepository.php
@@ -46,7 +46,7 @@ final readonly class DatabaseBaselineRepository implements BaselineRepository
         $key = $this->store->key('baseline', $connection, $queue, '_aggregate');
         $driver = $this->store->driver();
 
-        /** @var array<string, mixed> */
+        /** @var array<string, string> $data */
         $data = $driver->getHash($key);
 
         if (empty($data)) {
@@ -95,7 +95,7 @@ final readonly class DatabaseBaselineRepository implements BaselineRepository
         $key = $this->store->key('baseline', $connection, $queue, $jobClass);
         $driver = $this->store->driver();
 
-        /** @var array<string, mixed> */
+        /** @var array<string, string> $data */
         $data = $driver->getHash($key);
 
         if (empty($data)) {
@@ -134,7 +134,7 @@ final readonly class DatabaseBaselineRepository implements BaselineRepository
                 continue;
             }
 
-            /** @var array<string, mixed> */
+            /** @var array<string, string> $data */
             $data = $driver->getHash($key);
 
             if (empty($data)) {
@@ -224,6 +224,7 @@ final readonly class DatabaseBaselineRepository implements BaselineRepository
         $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
         $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
 
+        /** @var array<int, string> */
         return MetricsHash::notExpired()
             ->where('key', 'like', $sqlPattern)
             ->pluck('key')

--- a/src/Repositories/DatabaseBaselineRepository.php
+++ b/src/Repositories/DatabaseBaselineRepository.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Repositories;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\BaselineData;
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\BaselineRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+/**
+ * Database-based implementation of baseline repository.
+ */
+final readonly class DatabaseBaselineRepository implements BaselineRepository
+{
+    public function __construct(
+        private DatabaseMetricsStore $store,
+    ) {}
+
+    public function storeBaseline(BaselineData $baseline): void
+    {
+        $keyParts = $baseline->jobClass !== ''
+            ? ['baseline', $baseline->connection, $baseline->queue, $baseline->jobClass]
+            : ['baseline', $baseline->connection, $baseline->queue, '_aggregate'];
+
+        $key = $this->store->key(...$keyParts);
+        $driver = $this->store->driver();
+
+        $driver->setHash($key, [
+            'connection' => $baseline->connection,
+            'queue' => $baseline->queue,
+            'job_class' => $baseline->jobClass,
+            'cpu_percent_per_job' => (string) $baseline->cpuPercentPerJob,
+            'memory_mb_per_job' => (string) $baseline->memoryMbPerJob,
+            'avg_duration_ms' => (string) $baseline->avgDurationMs,
+            'sample_count' => $baseline->sampleCount,
+            'confidence_score' => (string) $baseline->confidenceScore,
+            'calculated_at' => $baseline->calculatedAt->timestamp,
+        ], $this->store->getTtl('baseline'));
+    }
+
+    public function getBaseline(string $connection, string $queue): ?BaselineData
+    {
+        $key = $this->store->key('baseline', $connection, $queue, '_aggregate');
+        $driver = $this->store->driver();
+
+        /** @var array<string, mixed> */
+        $data = $driver->getHash($key);
+
+        if (empty($data)) {
+            return null;
+        }
+
+        return BaselineData::fromArray([
+            'connection' => $data['connection'] ?? $connection,
+            'queue' => $data['queue'] ?? $queue,
+            'job_class' => $data['job_class'] ?? '',
+            'cpu_percent_per_job' => (float) ($data['cpu_percent_per_job'] ?? 0.0),
+            'memory_mb_per_job' => (float) ($data['memory_mb_per_job'] ?? 0.0),
+            'avg_duration_ms' => (float) ($data['avg_duration_ms'] ?? 0.0),
+            'sample_count' => (int) ($data['sample_count'] ?? 0),
+            'confidence_score' => (float) ($data['confidence_score'] ?? 0.0),
+            'calculated_at' => isset($data['calculated_at'])
+                ? Carbon::createFromTimestamp((int) $data['calculated_at'])->toIso8601String()
+                : null,
+        ]);
+    }
+
+    /**
+     * @param  array<int, array{connection: string, queue: string}>  $queuePairs
+     * @return array<string, BaselineData>
+     */
+    public function getBaselines(array $queuePairs): array
+    {
+        if (empty($queuePairs)) {
+            return [];
+        }
+
+        $baselines = [];
+
+        foreach ($queuePairs as $pair) {
+            $baseline = $this->getBaseline($pair['connection'], $pair['queue']);
+            if ($baseline !== null) {
+                $baselines["{$pair['connection']}:{$pair['queue']}"] = $baseline;
+            }
+        }
+
+        return $baselines;
+    }
+
+    public function getJobClassBaseline(string $connection, string $queue, string $jobClass): ?BaselineData
+    {
+        $key = $this->store->key('baseline', $connection, $queue, $jobClass);
+        $driver = $this->store->driver();
+
+        /** @var array<string, mixed> */
+        $data = $driver->getHash($key);
+
+        if (empty($data)) {
+            return null;
+        }
+
+        return BaselineData::fromArray([
+            'connection' => $data['connection'] ?? $connection,
+            'queue' => $data['queue'] ?? $queue,
+            'job_class' => $data['job_class'] ?? $jobClass,
+            'cpu_percent_per_job' => (float) ($data['cpu_percent_per_job'] ?? 0.0),
+            'memory_mb_per_job' => (float) ($data['memory_mb_per_job'] ?? 0.0),
+            'avg_duration_ms' => (float) ($data['avg_duration_ms'] ?? 0.0),
+            'sample_count' => (int) ($data['sample_count'] ?? 0),
+            'confidence_score' => (float) ($data['confidence_score'] ?? 0.0),
+            'calculated_at' => isset($data['calculated_at'])
+                ? Carbon::createFromTimestamp((int) $data['calculated_at'])->toIso8601String()
+                : null,
+        ]);
+    }
+
+    /**
+     * @return array<int, BaselineData>
+     */
+    public function getJobClassBaselines(string $connection, string $queue): array
+    {
+        $pattern = $this->store->key('baseline', $connection, $queue, '*');
+        $keys = $this->scanHashKeys($pattern);
+        $driver = $this->store->driver();
+
+        $baselines = [];
+
+        foreach ($keys as $key) {
+            // Skip aggregated baseline
+            if (str_ends_with($key, ':_aggregate')) {
+                continue;
+            }
+
+            /** @var array<string, mixed> */
+            $data = $driver->getHash($key);
+
+            if (empty($data)) {
+                continue;
+            }
+
+            $baselines[] = BaselineData::fromArray([
+                'connection' => $data['connection'] ?? $connection,
+                'queue' => $data['queue'] ?? $queue,
+                'job_class' => $data['job_class'] ?? '',
+                'cpu_percent_per_job' => (float) ($data['cpu_percent_per_job'] ?? 0.0),
+                'memory_mb_per_job' => (float) ($data['memory_mb_per_job'] ?? 0.0),
+                'avg_duration_ms' => (float) ($data['avg_duration_ms'] ?? 0.0),
+                'sample_count' => (int) ($data['sample_count'] ?? 0),
+                'confidence_score' => (float) ($data['confidence_score'] ?? 0.0),
+                'calculated_at' => isset($data['calculated_at'])
+                    ? Carbon::createFromTimestamp((int) $data['calculated_at'])->toIso8601String()
+                    : null,
+            ]);
+        }
+
+        return $baselines;
+    }
+
+    public function hasRecentBaseline(
+        string $connection,
+        string $queue,
+        int $maxAgeSeconds = 86400,
+    ): bool {
+        $baseline = $this->getBaseline($connection, $queue);
+
+        if ($baseline === null) {
+            return false;
+        }
+
+        $age = (int) Carbon::now()->timestamp - (int) $baseline->calculatedAt->timestamp;
+
+        return $age <= $maxAgeSeconds;
+    }
+
+    public function deleteBaseline(string $connection, string $queue): void
+    {
+        $pattern = $this->store->key('baseline', $connection, $queue, '*');
+        $keys = $this->scanHashKeys($pattern);
+
+        foreach ($keys as $key) {
+            $this->store->driver()->delete($key);
+        }
+    }
+
+    public function cleanup(int $olderThanSeconds): int
+    {
+        $pattern = $this->store->key('baseline', '*');
+        $keys = $this->scanHashKeys($pattern);
+        $driver = $this->store->driver();
+        $deleted = 0;
+
+        foreach ($keys as $key) {
+            $calculatedAt = $driver->getHashField($key, 'calculated_at');
+
+            if ($calculatedAt === null) {
+                continue;
+            }
+
+            $calculatedAtInt = is_numeric($calculatedAt) ? (int) $calculatedAt : 0;
+            $age = (int) Carbon::now()->timestamp - $calculatedAtInt;
+
+            if ($age > $olderThanSeconds) {
+                $driver->delete($key);
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Scan hash keys matching a pattern.
+     *
+     * Queries MetricsHash directly with LIKE pattern, consistent with
+     * the approach used in DatabaseJobMetricsRepository and DatabaseQueueMetricsRepository.
+     *
+     * @return array<int, string>
+     */
+    private function scanHashKeys(string $pattern): array
+    {
+        $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
+        $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
+
+        return MetricsHash::notExpired()
+            ->where('key', 'like', $sqlPattern)
+            ->pluck('key')
+            ->all();
+    }
+}

--- a/src/Repositories/DatabaseJobMetricsRepository.php
+++ b/src/Repositories/DatabaseJobMetricsRepository.php
@@ -231,7 +231,7 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
         $metrics = [];
 
         foreach ($keys as $key) {
-            /** @var array<string, mixed> */
+            /** @var array<string, string> $data */
             $data = $driver->getHash($key);
 
             if (empty($data)) {
@@ -269,7 +269,7 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
         $key = $this->store->key('jobs', $connection, $queue, $jobClass);
         $driver = $this->store->driver();
 
-        /** @var array<string, mixed> */
+        /** @var array<string, string> $data */
         $data = $driver->getHash($key);
 
         return [
@@ -626,6 +626,7 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
         $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
         $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
 
+        /** @var array<int, string> */
         return MetricsHash::notExpired()
             ->where('key', 'like', $sqlPattern)
             ->pluck('key')

--- a/src/Repositories/DatabaseJobMetricsRepository.php
+++ b/src/Repositories/DatabaseJobMetricsRepository.php
@@ -103,10 +103,12 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
             $ttl,
             $jobId
         ) {
-            $driver->incrementHashField($metricsKey, 'total_processed', 1);
-            $driver->incrementHashField($metricsKey, 'total_duration_ms', $durationMs);
-            $driver->incrementHashField($metricsKey, 'total_memory_mb', $memoryMb);
-            $driver->incrementHashField($metricsKey, 'total_cpu_time_ms', $cpuTimeMs);
+            $driver->incrementHashFields($metricsKey, [
+                'total_processed' => 1,
+                'total_duration_ms' => $durationMs,
+                'total_memory_mb' => $memoryMb,
+                'total_cpu_time_ms' => $cpuTimeMs,
+            ]);
             $driver->setHash($metricsKey, ['last_processed_at' => $completedAt->timestamp]);
 
             // Store samples in sorted sets with timestamp as score
@@ -177,8 +179,8 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
                 $failedAt,
                 $ttl
             ) {
-                // Job-level failure metrics
-                $driver->incrementHashField($metricsKey, 'total_failed', 1);
+                // Job-level failure metrics (combine increment + setHash into one transaction)
+                $driver->incrementHashFields($metricsKey, ['total_failed' => 1]);
                 $driver->setHash($metricsKey, [
                     'last_failed_at' => $failedAt->timestamp,
                     'last_exception' => substr($exception, 0, 1000),
@@ -189,8 +191,8 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
                 $driver->addToSet($discoveryKey, [$serverKey]);
                 $driver->expire($discoveryKey, $ttl);
 
-                // Hostname-level failure metrics
-                $driver->incrementHashField($serverKey, 'total_failed', 1);
+                // Hostname-level failure metrics (combine increment + setHash into one transaction)
+                $driver->incrementHashFields($serverKey, ['total_failed' => 1]);
                 $driver->setHash($serverKey, ['last_updated_at' => $failedAt->timestamp]);
                 $driver->expire($serverKey, $ttl);
 
@@ -199,7 +201,7 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
             });
         } else {
             $this->store->transaction(function () use ($driver, $metricsKey, $jobKey, $exception, $failedAt, $ttl) {
-                $driver->incrementHashField($metricsKey, 'total_failed', 1);
+                $driver->incrementHashFields($metricsKey, ['total_failed' => 1]);
                 $driver->setHash($metricsKey, [
                     'last_failed_at' => $failedAt->timestamp,
                     'last_exception' => substr($exception, 0, 1000),
@@ -577,10 +579,12 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
             $driver->expire($discoveryKey, $ttl);
 
             if ($success) {
-                $driver->incrementHashField($serverKey, 'total_processed', 1);
-                $driver->incrementHashField($serverKey, 'total_duration_ms', $durationMs);
+                $driver->incrementHashFields($serverKey, [
+                    'total_processed' => 1,
+                    'total_duration_ms' => $durationMs,
+                ]);
             } else {
-                $driver->incrementHashField($serverKey, 'total_failed', 1);
+                $driver->incrementHashFields($serverKey, ['total_failed' => 1]);
             }
             $driver->setHash($serverKey, ['last_updated_at' => $timestamp->timestamp]);
             $driver->expire($serverKey, $ttl);

--- a/src/Repositories/DatabaseJobMetricsRepository.php
+++ b/src/Repositories/DatabaseJobMetricsRepository.php
@@ -1,0 +1,634 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Repositories;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+/**
+ * Database-based implementation of job metrics repository.
+ */
+final readonly class DatabaseJobMetricsRepository implements JobMetricsRepository
+{
+    public function __construct(
+        private DatabaseMetricsStore $store,
+    ) {}
+
+    public function recordStart(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $startedAt,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $jobKey = $this->store->key('job', (string) $jobId);
+        $jobDiscoveryKey = $this->store->key('discovery', 'jobs');
+        $queueDiscoveryKey = $this->store->key('discovery', 'queues');
+        $ttl = $this->store->getTtl('raw');
+        $discoveryTtl = $this->store->getTtl('aggregated');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use (
+            $driver,
+            $jobDiscoveryKey,
+            $queueDiscoveryKey,
+            $metricsKey,
+            $jobKey,
+            $connection,
+            $queue,
+            $jobClass,
+            $startedAt,
+            $ttl,
+            $discoveryTtl
+        ) {
+            // Register queue in discovery set (push-based tracking)
+            $driver->addToSet($queueDiscoveryKey, ["{$connection}:{$queue}"]);
+            $driver->expire($queueDiscoveryKey, $discoveryTtl);
+
+            // Register job in discovery set (push-based tracking)
+            $driver->addToSet($jobDiscoveryKey, ["{$connection}:{$queue}:{$jobClass}"]);
+            $driver->expire($jobDiscoveryKey, $discoveryTtl);
+
+            // Increment total queued counter
+            $driver->incrementHashField($metricsKey, 'total_queued', 1);
+
+            // Store job start time
+            $driver->setHash($jobKey, [
+                'job_class' => $jobClass,
+                'connection' => $connection,
+                'queue' => $queue,
+                'started_at' => $startedAt->timestamp,
+            ], $ttl);
+
+            // Ensure TTL is set on metrics key
+            $driver->expire($metricsKey, $ttl);
+        });
+    }
+
+    public function recordCompletion(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        float $durationMs,
+        float $memoryMb,
+        float $cpuTimeMs,
+        Carbon $completedAt,
+        ?string $hostname = null,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $durationKey = $this->store->key('durations', $connection, $queue, $jobClass);
+        $memoryKey = $this->store->key('memory', $connection, $queue, $jobClass);
+        $cpuKey = $this->store->key('cpu', $connection, $queue, $jobClass);
+        $ttl = $this->store->getTtl('raw');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use (
+            $driver,
+            $metricsKey,
+            $durationKey,
+            $memoryKey,
+            $cpuKey,
+            $durationMs,
+            $memoryMb,
+            $cpuTimeMs,
+            $completedAt,
+            $ttl,
+            $jobId
+        ) {
+            $driver->incrementHashField($metricsKey, 'total_processed', 1);
+            $driver->incrementHashField($metricsKey, 'total_duration_ms', $durationMs);
+            $driver->incrementHashField($metricsKey, 'total_memory_mb', $memoryMb);
+            $driver->incrementHashField($metricsKey, 'total_cpu_time_ms', $cpuTimeMs);
+            $driver->setHash($metricsKey, ['last_processed_at' => $completedAt->timestamp]);
+
+            // Store samples in sorted sets with timestamp as score
+            // Member format: "jobId:value" for unique entries per job
+            $durationMember = $jobId.':'.$durationMs;
+            $driver->addToSortedSet($durationKey, [$durationMember => (int) $completedAt->timestamp], $ttl);
+
+            $memoryMember = $jobId.':'.$memoryMb;
+            $driver->addToSortedSet($memoryKey, [$memoryMember => (int) $completedAt->timestamp], $ttl);
+
+            $cpuMember = $jobId.':'.$cpuTimeMs;
+            $driver->addToSortedSet($cpuKey, [$cpuMember => (int) $completedAt->timestamp], $ttl);
+
+            // Refresh TTL on metrics key
+            $driver->expire($metricsKey, $ttl);
+
+            // Keep only recent samples (limit to 10000)
+            if (mt_rand(1, 100) <= 2) {
+                $driver->removeSortedSetByRank($durationKey, 0, -10001);
+                $driver->removeSortedSetByRank($memoryKey, 0, -10001);
+                $driver->removeSortedSetByRank($cpuKey, 0, -10001);
+            }
+        });
+
+        // Store hostname-scoped metrics if hostname is provided
+        if ($hostname !== null) {
+            $this->recordHostnameMetrics(
+                $hostname,
+                $connection,
+                $queue,
+                $jobClass,
+                $durationMs,
+                true,
+                $completedAt
+            );
+        }
+
+        // Clean up job tracking key
+        $this->store->driver()->delete($this->store->key('job', (string) $jobId));
+    }
+
+    public function recordFailure(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        string $exception,
+        Carbon $failedAt,
+        ?string $hostname = null,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $jobKey = $this->store->key('job', (string) $jobId);
+        $ttl = $this->store->getTtl('raw');
+
+        $driver = $this->store->driver();
+
+        if ($hostname !== null) {
+            $serverKey = $this->store->key('server_jobs', $hostname, $connection, $queue, $jobClass);
+            $discoveryKey = $this->store->key('discovery', 'server_jobs', $hostname);
+
+            $this->store->transaction(function () use (
+                $driver,
+                $metricsKey,
+                $serverKey,
+                $discoveryKey,
+                $jobKey,
+                $exception,
+                $failedAt,
+                $ttl
+            ) {
+                // Job-level failure metrics
+                $driver->incrementHashField($metricsKey, 'total_failed', 1);
+                $driver->setHash($metricsKey, [
+                    'last_failed_at' => $failedAt->timestamp,
+                    'last_exception' => substr($exception, 0, 1000),
+                ]);
+                $driver->expire($metricsKey, $ttl);
+
+                // Register server key in discovery set
+                $driver->addToSet($discoveryKey, [$serverKey]);
+                $driver->expire($discoveryKey, $ttl);
+
+                // Hostname-level failure metrics
+                $driver->incrementHashField($serverKey, 'total_failed', 1);
+                $driver->setHash($serverKey, ['last_updated_at' => $failedAt->timestamp]);
+                $driver->expire($serverKey, $ttl);
+
+                // Clean up job tracking key
+                $driver->delete($jobKey);
+            });
+        } else {
+            $this->store->transaction(function () use ($driver, $metricsKey, $jobKey, $exception, $failedAt, $ttl) {
+                $driver->incrementHashField($metricsKey, 'total_failed', 1);
+                $driver->setHash($metricsKey, [
+                    'last_failed_at' => $failedAt->timestamp,
+                    'last_exception' => substr($exception, 0, 1000),
+                ]);
+                $driver->expire($metricsKey, $ttl);
+
+                // Clean up job tracking key
+                $driver->delete($jobKey);
+            });
+        }
+    }
+
+    /**
+     * @return array<string, array{total_processed: int, total_failed: int, total_duration_ms: float, failure_rate: float, avg_duration_ms: float}>
+     */
+    public function getHostnameJobMetrics(string $hostname): array
+    {
+        $driver = $this->store->driver();
+
+        // Use discovery set to find server job keys
+        $discoveryKey = $this->store->key('discovery', 'server_jobs', $hostname);
+        $keys = $driver->getSetMembers($discoveryKey);
+
+        // Fallback: scan hash keys matching pattern
+        if (empty($keys)) {
+            $keys = $this->scanHashKeys($this->store->key('server_jobs', $hostname, '*'));
+        }
+
+        $metrics = [];
+
+        foreach ($keys as $key) {
+            /** @var array<string, mixed> */
+            $data = $driver->getHash($key);
+
+            if (empty($data)) {
+                continue;
+            }
+
+            $totalProcessed = (int) ($data['total_processed'] ?? 0);
+            $totalFailed = (int) ($data['total_failed'] ?? 0);
+            $totalDurationMs = (float) ($data['total_duration_ms'] ?? 0.0);
+
+            $totalJobs = $totalProcessed + $totalFailed;
+            $failureRate = $totalJobs > 0 ? ($totalFailed / $totalJobs) * 100 : 0.0;
+            $avgDurationMs = $totalProcessed > 0 ? $totalDurationMs / $totalProcessed : 0.0;
+
+            $metrics[$key] = [
+                'total_processed' => $totalProcessed,
+                'total_failed' => $totalFailed,
+                'total_duration_ms' => $totalDurationMs,
+                'failure_rate' => round($failureRate, 2),
+                'avg_duration_ms' => round($avgDurationMs, 2),
+            ];
+        }
+
+        return $metrics;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMetrics(
+        string $jobClass,
+        string $connection,
+        string $queue,
+    ): array {
+        $key = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $driver = $this->store->driver();
+
+        /** @var array<string, mixed> */
+        $data = $driver->getHash($key);
+
+        return [
+            'total_processed' => (int) ($data['total_processed'] ?? 0),
+            'total_failed' => (int) ($data['total_failed'] ?? 0),
+            'total_duration_ms' => (float) ($data['total_duration_ms'] ?? 0.0),
+            'total_memory_mb' => (float) ($data['total_memory_mb'] ?? 0.0),
+            'total_cpu_time_ms' => (float) ($data['total_cpu_time_ms'] ?? 0.0),
+            'last_processed_at' => isset($data['last_processed_at'])
+                ? Carbon::createFromTimestamp((int) $data['last_processed_at'])
+                : null,
+            'last_failed_at' => isset($data['last_failed_at'])
+                ? Carbon::createFromTimestamp((int) $data['last_failed_at'])
+                : null,
+            'last_exception' => $data['last_exception'] ?? null,
+        ];
+    }
+
+    /**
+     * Get duration samples for job performance analysis.
+     *
+     * Returns the most recent duration measurements in chronological order.
+     * Samples are stored as "jobId:value" members in sorted sets with
+     * timestamp scores for time-based querying.
+     *
+     * @return array<int, float> Duration values in milliseconds, chronologically ordered
+     */
+    public function getDurationSamples(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        int $limit = 1000,
+    ): array {
+        $key = $this->store->key('durations', $connection, $queue, $jobClass);
+
+        return $this->parseSamples(
+            $this->store->driver()->getSortedSetByRank($key, -$limit, -1)
+        );
+    }
+
+    /**
+     * Get memory usage samples for resource analysis.
+     *
+     * @return array<int, float> Memory values in megabytes, chronologically ordered
+     */
+    public function getMemorySamples(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        int $limit = 1000,
+    ): array {
+        $key = $this->store->key('memory', $connection, $queue, $jobClass);
+
+        return $this->parseSamples(
+            $this->store->driver()->getSortedSetByRank($key, -$limit, -1)
+        );
+    }
+
+    /**
+     * Get CPU time samples for performance analysis.
+     *
+     * @return array<int, float> CPU time values in milliseconds, chronologically ordered
+     */
+    public function getCpuTimeSamples(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        int $limit = 1000,
+    ): array {
+        $key = $this->store->key('cpu', $connection, $queue, $jobClass);
+
+        return $this->parseSamples(
+            $this->store->driver()->getSortedSetByRank($key, -$limit, -1)
+        );
+    }
+
+    public function getThroughput(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        int $windowSeconds,
+    ): int {
+        $key = $this->store->key('durations', $connection, $queue, $jobClass);
+        $cutoff = (string) Carbon::now()->subSeconds($windowSeconds)->timestamp;
+
+        return $this->store->driver()->countSortedSetByScore($key, $cutoff, '+inf');
+    }
+
+    public function getAverageDurationInWindow(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        int $windowSeconds,
+    ): float {
+        $key = $this->store->key('durations', $connection, $queue, $jobClass);
+        $cutoff = (string) Carbon::now()->subSeconds($windowSeconds)->timestamp;
+        $samples = $this->store->driver()->getSortedSetByScore($key, $cutoff, '+inf');
+
+        if (empty($samples)) {
+            return 0.0;
+        }
+
+        $sum = 0.0;
+        $count = 0;
+        foreach ($samples as $member) {
+            $colonPos = strrpos($member, ':');
+            if ($colonPos !== false) {
+                $sum += (float) substr($member, $colonPos + 1);
+                $count++;
+            }
+        }
+
+        return $count > 0 ? $sum / $count : 0.0;
+    }
+
+    public function recordQueuedAt(
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $queuedAt,
+    ): void {
+        $key = $this->store->key('queued', $connection, $queue, $jobClass);
+        $driver = $this->store->driver();
+
+        $driver->addToSortedSet(
+            $key,
+            [(string) $queuedAt->timestamp => (int) $queuedAt->timestamp],
+            $this->store->getTtl('raw')
+        );
+    }
+
+    public function recordRetryRequested(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $retryRequestedAt,
+        int $attemptNumber,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $retryKey = $this->store->key('retries', $connection, $queue, $jobClass);
+        $ttl = $this->store->getTtl('raw');
+        $retryData = json_encode(['job_id' => $jobId, 'attempt' => $attemptNumber], JSON_THROW_ON_ERROR);
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use (
+            $driver,
+            $metricsKey,
+            $retryKey,
+            $retryData,
+            $retryRequestedAt,
+            $ttl
+        ) {
+            // Increment retry counter
+            $driver->incrementHashField($metricsKey, 'total_retries', 1);
+
+            // Store retry event for pattern analysis
+            $driver->addToSortedSet($retryKey, [
+                $retryData => (int) $retryRequestedAt->timestamp,
+            ], $ttl);
+
+            // Refresh TTL on metrics key
+            $driver->expire($metricsKey, $ttl);
+        });
+    }
+
+    public function recordTimeout(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $timedOutAt,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $ttl = $this->store->getTtl('raw');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use ($driver, $metricsKey, $timedOutAt, $ttl) {
+            $driver->incrementHashField($metricsKey, 'total_timeouts', 1);
+            $driver->setHash($metricsKey, ['last_timeout_at' => $timedOutAt->timestamp]);
+            $driver->expire($metricsKey, $ttl);
+        });
+    }
+
+    public function recordException(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        string $exceptionClass,
+        string $exceptionMessage,
+        Carbon $occurredAt,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $exceptionsKey = $this->store->key('exceptions', $connection, $queue, $jobClass);
+        $ttl = $this->store->getTtl('raw');
+        $aggregatedTtl = $this->store->getTtl('aggregated');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use (
+            $driver,
+            $metricsKey,
+            $exceptionsKey,
+            $exceptionClass,
+            $ttl,
+            $aggregatedTtl
+        ) {
+            // Increment exception counter
+            $driver->incrementHashField($metricsKey, 'total_exceptions', 1);
+
+            // Track exception types
+            $driver->incrementHashField($exceptionsKey, $exceptionClass, 1);
+            $driver->expire($exceptionsKey, $aggregatedTtl);
+
+            // Refresh TTL on metrics key
+            $driver->expire($metricsKey, $ttl);
+        });
+    }
+
+    public function cleanup(int $olderThanSeconds): int
+    {
+        $pattern = $this->store->key('jobs', '*');
+        $keys = $this->scanHashKeys($pattern);
+        $driver = $this->store->driver();
+        $deleted = 0;
+
+        foreach ($keys as $key) {
+            $data = $driver->getHash($key);
+            $lastProcessed = $data['last_processed_at'] ?? null;
+
+            if ($lastProcessed === null) {
+                continue;
+            }
+
+            $lastProcessedInt = is_numeric($lastProcessed) ? (int) $lastProcessed : 0;
+            $age = (int) Carbon::now()->timestamp - $lastProcessedInt;
+
+            if ($age > $olderThanSeconds) {
+                $driver->delete($key);
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * List all discovered jobs using discovery set.
+     *
+     * @return array<int, array{connection: string, queue: string, jobClass: string}>
+     */
+    public function listJobs(): array
+    {
+        $key = $this->store->key('discovery', 'jobs');
+        $members = $this->store->driver()->getSetMembers($key);
+
+        $jobs = [];
+        foreach ($members as $member) {
+            // Parse "connection:queue:JobClass" format
+            $parts = explode(':', $member, 3);
+            if (count($parts) === 3) {
+                $jobs[] = [
+                    'connection' => $parts[0],
+                    'queue' => $parts[1],
+                    'jobClass' => $parts[2],
+                ];
+            }
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Register job in discovery set (push-based tracking).
+     */
+    public function markJobDiscovered(string $connection, string $queue, string $jobClass): void
+    {
+        $key = $this->store->key('discovery', 'jobs');
+        $this->store->driver()->addToSet($key, ["{$connection}:{$queue}:{$jobClass}"]);
+    }
+
+    /**
+     * Record hostname-scoped job metrics for server-level aggregation.
+     */
+    private function recordHostnameMetrics(
+        string $hostname,
+        string $connection,
+        string $queue,
+        string $jobClass,
+        float $durationMs,
+        bool $success,
+        Carbon $timestamp,
+    ): void {
+        $serverKey = $this->store->key('server_jobs', $hostname, $connection, $queue, $jobClass);
+        $discoveryKey = $this->store->key('discovery', 'server_jobs', $hostname);
+        $ttl = $this->store->getTtl('raw');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use ($driver, $serverKey, $discoveryKey, $durationMs, $success, $timestamp, $ttl) {
+            $driver->addToSet($discoveryKey, [$serverKey]);
+            $driver->expire($discoveryKey, $ttl);
+
+            if ($success) {
+                $driver->incrementHashField($serverKey, 'total_processed', 1);
+                $driver->incrementHashField($serverKey, 'total_duration_ms', $durationMs);
+            } else {
+                $driver->incrementHashField($serverKey, 'total_failed', 1);
+            }
+            $driver->setHash($serverKey, ['last_updated_at' => $timestamp->timestamp]);
+            $driver->expire($serverKey, $ttl);
+        });
+    }
+
+    /**
+     * Parse sample members from sorted set format "jobId:value" to float values.
+     *
+     * Members are stored as "{jobId}:{value}" (e.g., "job-1:150.0") and returned
+     * in reverse chronological order from getSortedSetByRank. This method extracts
+     * the numeric value after the last colon and returns samples in chronological order.
+     *
+     * @param  array<int, string>  $samples  Raw members from sorted set
+     * @return array<int, float> Parsed float values in chronological order
+     */
+    private function parseSamples(array $samples): array
+    {
+        if (empty($samples)) {
+            return [];
+        }
+
+        return collect($samples)
+            ->map(function (string $member): float {
+                $colonPos = strrpos($member, ':');
+
+                return $colonPos !== false ? (float) substr($member, $colonPos + 1) : 0.0;
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Scan hash keys matching a pattern.
+     *
+     * Unlike scanKeys on the store (which scans MetricsKey), this method
+     * scans MetricsHash for keys matching the given LIKE pattern.
+     *
+     * @return array<int, string>
+     */
+    private function scanHashKeys(string $pattern): array
+    {
+        $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
+        $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
+
+        return MetricsHash::notExpired()
+            ->where('key', 'like', $sqlPattern)
+            ->pluck('key')
+            ->all();
+    }
+}

--- a/src/Repositories/DatabaseQueueMetricsRepository.php
+++ b/src/Repositories/DatabaseQueueMetricsRepository.php
@@ -254,6 +254,7 @@ final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepos
         $sqlPattern = str_replace(['%'], ['\\%'], $pattern);
         $sqlPattern = str_replace(['*', '?'], ['%', '_'], $sqlPattern);
 
+        /** @var array<int, string> */
         return MetricsHash::notExpired()
             ->where('key', 'like', $sqlPattern)
             ->pluck('key')

--- a/src/Repositories/DatabaseQueueMetricsRepository.php
+++ b/src/Repositories/DatabaseQueueMetricsRepository.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Repositories;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+use Cbox\LaravelQueueMetrics\Support\MetricsConstants;
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * Database-based implementation of queue metrics repository.
+ */
+final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepository
+{
+    public function __construct(
+        private DatabaseMetricsStore $store,
+    ) {}
+
+    /**
+     * @return array{depth: int, pending: int, scheduled: int, reserved: int, oldest_job_age: int}
+     */
+    public function getQueueState(string $connection, string $queue): array
+    {
+        $queueManager = Queue::connection($connection);
+
+        // Get queue size (pending jobs)
+        $size = $queueManager->size($queue);
+
+        // For detailed metrics, we'd need to query the queue backend directly
+        // This is a simplified version - extend based on your queue driver
+        return [
+            'depth' => $size,
+            'pending' => $size,
+            'scheduled' => 0,
+            'reserved' => 0,
+            'oldest_job_age' => 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metrics
+     */
+    public function recordSnapshot(
+        string $connection,
+        string $queue,
+        array $metrics,
+    ): void {
+        $key = $this->store->key('queue_snapshot', $connection, $queue);
+        $timestampKey = $this->store->key('queue_snapshots', $connection, $queue);
+
+        $driver = $this->store->driver();
+        $now = Carbon::now();
+        $ttl = $this->store->getTtl('aggregated');
+
+        // Store latest snapshot
+        $driver->setHash($key, array_merge($metrics, [
+            'recorded_at' => $now->timestamp,
+        ]), $ttl);
+
+        // Add to time-series (sorted set)
+        $driver->addToSortedSet($timestampKey, [
+            json_encode($metrics, JSON_THROW_ON_ERROR) => (int) $now->timestamp,
+        ], $ttl);
+
+        // Keep only recent snapshots (last 1000)
+        $driver->removeSortedSetByRank($timestampKey, 0, -1001);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getLatestMetrics(string $connection, string $queue): array
+    {
+        $key = $this->store->key('queue_snapshot', $connection, $queue);
+        $driver = $this->store->driver();
+
+        /** @var array<string, string> */
+        $data = $driver->getHash($key) ?: [];
+
+        if (empty($data)) {
+            return [];
+        }
+
+        return [
+            'depth' => (int) ($data['depth'] ?? 0),
+            'pending' => (int) ($data['pending'] ?? 0),
+            'scheduled' => (int) ($data['scheduled'] ?? 0),
+            'reserved' => (int) ($data['reserved'] ?? 0),
+            'oldest_job_age' => (int) ($data['oldest_job_age'] ?? 0),
+            'throughput_per_minute' => (float) ($data['throughput_per_minute'] ?? 0.0),
+            'avg_duration' => (float) ($data['avg_duration'] ?? 0.0),
+            'failure_rate' => (float) ($data['failure_rate'] ?? 0.0),
+            'utilization_rate' => (float) ($data['utilization_rate'] ?? 0.0),
+            'active_workers' => (int) ($data['active_workers'] ?? 0),
+            'recorded_at' => isset($data['recorded_at'])
+                ? Carbon::createFromTimestamp((int) $data['recorded_at'])
+                : null,
+        ];
+    }
+
+    /**
+     * @return array{status: string, score: float}
+     */
+    public function getHealthStatus(string $connection, string $queue): array
+    {
+        $metrics = $this->getLatestMetrics($connection, $queue);
+
+        if (empty($metrics)) {
+            return ['status' => 'unknown', 'score' => 0.0];
+        }
+
+        $score = $this->calculateHealthScore($metrics);
+
+        $status = match (true) {
+            $score >= 80.0 => 'healthy',
+            $score >= 50.0 => 'warning',
+            default => 'critical',
+        };
+
+        // Check if health score changed significantly and dispatch event
+        $previousScore = $this->getPreviousHealthScore($connection, $queue);
+        if ($previousScore !== null) {
+            $scoreChange = abs($score - $previousScore);
+            $threshold = MetricsConstants::HEALTH_SCORE_CHANGE_THRESHOLD;
+
+            if ($scoreChange >= $threshold) {
+                HealthScoreChanged::dispatch(
+                    $connection,
+                    $queue,
+                    round($score, 2),
+                    round($previousScore, 2),
+                    $status
+                );
+            }
+        }
+
+        // Store current score for next comparison
+        $this->storeCurrentHealthScore($connection, $queue, $score);
+
+        return ['status' => $status, 'score' => $score];
+    }
+
+    /**
+     * List all discovered queues using discovery set.
+     *
+     * @return array<int, array{connection: string, queue: string}>
+     */
+    public function listQueues(): array
+    {
+        $key = $this->store->key('discovery', 'queues');
+        $members = $this->store->driver()->getSetMembers($key);
+
+        $queues = [];
+        foreach ($members as $member) {
+            // Parse "connection:queue" format
+            $parts = explode(':', $member, 2);
+            if (count($parts) === 2) {
+                $queues[] = [
+                    'connection' => $parts[0],
+                    'queue' => $parts[1],
+                ];
+            }
+        }
+
+        return $queues;
+    }
+
+    /**
+     * Register queue in discovery set (push-based tracking).
+     */
+    public function markQueueDiscovered(string $connection, string $queue): void
+    {
+        $key = $this->store->key('discovery', 'queues');
+        $this->store->driver()->addToSet($key, ["{$connection}:{$queue}"]);
+    }
+
+    public function cleanup(int $olderThanSeconds): int
+    {
+        $pattern = $this->store->key('queue_snapshot', '*', '*');
+        $keys = $this->scanHashKeys($pattern);
+        $driver = $this->store->driver();
+        $deleted = 0;
+
+        foreach ($keys as $key) {
+            $recordedAt = $driver->getHashField($key, 'recorded_at');
+
+            if ($recordedAt === null || $recordedAt === false) {
+                continue;
+            }
+
+            $recordedAtInt = is_numeric($recordedAt) ? (int) $recordedAt : 0;
+            $age = (int) Carbon::now()->timestamp - $recordedAtInt;
+
+            if ($age > $olderThanSeconds) {
+                $driver->delete($key);
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @param  array<string, mixed>  $metrics
+     */
+    private function calculateHealthScore(array $metrics): float
+    {
+        $score = 100.0;
+
+        // Penalize for queue depth
+        $depthValue = $metrics['depth'] ?? 0;
+        $depth = is_numeric($depthValue) ? (int) $depthValue : 0;
+        if ($depth > 100) {
+            $score -= min(30, ($depth - 100) / 10);
+        }
+
+        // Penalize for old jobs
+        $oldestAgeValue = $metrics['oldest_job_age'] ?? 0;
+        $oldestAge = is_numeric($oldestAgeValue) ? (int) $oldestAgeValue : 0;
+        if ($oldestAge > 300) { // 5 minutes
+            $score -= min(30, ($oldestAge - 300) / 60);
+        }
+
+        // Penalize for high failure rate
+        $failureRateValue = $metrics['failure_rate'] ?? 0.0;
+        $failureRate = is_numeric($failureRateValue) ? (float) $failureRateValue : 0.0;
+        $score -= min(20, $failureRate);
+
+        // Penalize for no active workers
+        $activeWorkersValue = $metrics['active_workers'] ?? 0;
+        $activeWorkers = is_numeric($activeWorkersValue) ? (int) $activeWorkersValue : 0;
+        if ($activeWorkers === 0 && $depth > 0) {
+            $score -= 20;
+        }
+
+        return max(0.0, $score);
+    }
+
+    /**
+     * Scan hash keys matching a pattern.
+     *
+     * Unlike scanKeys on the store (which scans MetricsKey), this method
+     * scans MetricsHash for keys matching the given LIKE pattern.
+     *
+     * @return array<int, string>
+     */
+    private function scanHashKeys(string $pattern): array
+    {
+        $sqlPattern = str_replace(['%'], ['\\%'], $pattern);
+        $sqlPattern = str_replace(['*', '?'], ['%', '_'], $sqlPattern);
+
+        return MetricsHash::notExpired()
+            ->where('key', 'like', $sqlPattern)
+            ->pluck('key')
+            ->all();
+    }
+
+    /**
+     * Get previous health score for comparison.
+     */
+    private function getPreviousHealthScore(string $connection, string $queue): ?float
+    {
+        $key = $this->store->key('health_score', $connection, $queue);
+        $score = $this->store->driver()->get($key);
+
+        if ($score === null || $score === false) {
+            return null;
+        }
+
+        return is_numeric($score) ? (float) $score : null;
+    }
+
+    /**
+     * Store current health score for next comparison.
+     */
+    private function storeCurrentHealthScore(string $connection, string $queue, float $score): void
+    {
+        $key = $this->store->key('health_score', $connection, $queue);
+        $ttl = 3600; // Keep for 1 hour
+        $this->store->driver()->set($key, (string) $score, $ttl);
+    }
+}

--- a/src/Repositories/DatabaseWorkerHeartbeatRepository.php
+++ b/src/Repositories/DatabaseWorkerHeartbeatRepository.php
@@ -40,8 +40,9 @@ final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbea
             $existing = $this->store->getHash($key);
 
             $now = Carbon::now();
+            /** @var array<string, string> $existing */
             $previousState = $existing['state'] ?? null;
-            $lastHeartbeat = isset($existing['last_heartbeat']) ? (int) $existing['last_heartbeat'] : $now->timestamp;
+            $lastHeartbeat = isset($existing['last_heartbeat']) ? (int) $existing['last_heartbeat'] : $now->getTimestamp();
             $idleTime = (float) ($existing['idle_time_seconds'] ?? 0.0);
             $busyTime = (float) ($existing['busy_time_seconds'] ?? 0.0);
             $jobsProcessed = (int) ($existing['jobs_processed'] ?? 0);
@@ -49,7 +50,7 @@ final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbea
             $lastStateChange = isset($existing['last_state_change']) ? (int) $existing['last_state_change'] : $now->timestamp;
 
             // Time since last heartbeat
-            $timeSinceLastHeartbeat = $now->timestamp - $lastHeartbeat;
+            $timeSinceLastHeartbeat = $now->getTimestamp() - $lastHeartbeat;
 
             // Update time in previous state
             if ($previousState === 'idle') {
@@ -94,7 +95,7 @@ final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbea
 
             $this->store->addToSortedSet(
                 $this->store->key('workers', 'all'),
-                [$workerId => $now->timestamp]
+                [$workerId => (int) $now->timestamp]
             );
         });
     }

--- a/src/Repositories/DatabaseWorkerHeartbeatRepository.php
+++ b/src/Repositories/DatabaseWorkerHeartbeatRepository.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMetrics\DataTransferObjects\WorkerHeartbeat;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
 use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+use Cbox\LaravelQueueMetrics\Support\HeartbeatThrottleCache;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -35,6 +36,14 @@ final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbea
         float $memoryUsageMb = 0.0,
         float $cpuUsagePercent = 0.0,
     ): void {
+        $currentTimestamp = Carbon::now()->getTimestamp();
+
+        // Throttle non-state-change heartbeats for the database driver.
+        // State changes always write immediately; identical states skip if written recently.
+        if (HeartbeatThrottleCache::shouldSkip($workerId, $state->value, $currentTimestamp)) {
+            return;
+        }
+
         DB::transaction(function () use ($workerId, $connection, $queue, $state, $currentJobId, $currentJobClass, $pid, $hostname, $memoryUsageMb, $cpuUsagePercent) {
             $key = $this->store->key('worker', $workerId);
             $existing = $this->store->getHash($key);
@@ -98,6 +107,9 @@ final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbea
                 [$workerId => (int) $now->timestamp]
             );
         });
+
+        // Update throttle tracking after successful write
+        HeartbeatThrottleCache::record($workerId, $state->value, $currentTimestamp);
     }
 
     public function transitionState(

--- a/src/Repositories/DatabaseWorkerHeartbeatRepository.php
+++ b/src/Repositories/DatabaseWorkerHeartbeatRepository.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Repositories;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\WorkerHeartbeat;
+use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Database-based implementation of worker heartbeat repository.
+ *
+ * Replaces the Redis Lua script with DB::transaction for atomic heartbeat updates.
+ */
+final readonly class DatabaseWorkerHeartbeatRepository implements WorkerHeartbeatRepository
+{
+    public function __construct(
+        private DatabaseMetricsStore $store,
+    ) {}
+
+    public function recordHeartbeat(
+        string $workerId,
+        string $connection,
+        string $queue,
+        WorkerState $state,
+        string|int|null $currentJobId,
+        ?string $currentJobClass,
+        int $pid,
+        string $hostname,
+        float $memoryUsageMb = 0.0,
+        float $cpuUsagePercent = 0.0,
+    ): void {
+        DB::transaction(function () use ($workerId, $connection, $queue, $state, $currentJobId, $currentJobClass, $pid, $hostname, $memoryUsageMb, $cpuUsagePercent) {
+            $key = $this->store->key('worker', $workerId);
+            $existing = $this->store->getHash($key);
+
+            $now = Carbon::now();
+            $previousState = $existing['state'] ?? null;
+            $lastHeartbeat = isset($existing['last_heartbeat']) ? (int) $existing['last_heartbeat'] : $now->timestamp;
+            $idleTime = (float) ($existing['idle_time_seconds'] ?? 0.0);
+            $busyTime = (float) ($existing['busy_time_seconds'] ?? 0.0);
+            $jobsProcessed = (int) ($existing['jobs_processed'] ?? 0);
+            $previousPeakMemory = (float) ($existing['peak_memory_usage_mb'] ?? 0.0);
+            $lastStateChange = isset($existing['last_state_change']) ? (int) $existing['last_state_change'] : $now->timestamp;
+
+            // Time since last heartbeat
+            $timeSinceLastHeartbeat = $now->timestamp - $lastHeartbeat;
+
+            // Update time in previous state
+            if ($previousState === 'idle') {
+                $idleTime += $timeSinceLastHeartbeat;
+            } elseif ($previousState === 'busy') {
+                $busyTime += $timeSinceLastHeartbeat;
+            }
+
+            // Increment jobs_processed on busy→idle transition
+            if ($previousState === 'busy' && $state->value === 'idle' && $currentJobId === null) {
+                $jobsProcessed++;
+            }
+
+            // Update last_state_change if state changed
+            if ($previousState !== $state->value) {
+                $lastStateChange = $now->timestamp;
+            }
+
+            // Track peak memory
+            $peakMemory = max($previousPeakMemory, $memoryUsageMb);
+
+            $ttl = $this->store->getTtl('raw');
+
+            $this->store->setHash($key, [
+                'worker_id' => $workerId,
+                'connection' => $connection,
+                'queue' => $queue,
+                'state' => $state->value,
+                'last_heartbeat' => $now->timestamp,
+                'last_state_change' => $lastStateChange,
+                'current_job_id' => $currentJobId !== null ? (string) $currentJobId : '',
+                'current_job_class' => $currentJobClass ?? '',
+                'idle_time_seconds' => $idleTime,
+                'busy_time_seconds' => $busyTime,
+                'jobs_processed' => $jobsProcessed,
+                'pid' => $pid,
+                'hostname' => $hostname,
+                'memory_usage_mb' => $memoryUsageMb,
+                'cpu_usage_percent' => $cpuUsagePercent,
+                'peak_memory_usage_mb' => $peakMemory,
+            ], $ttl);
+
+            $this->store->addToSortedSet(
+                $this->store->key('workers', 'all'),
+                [$workerId => $now->timestamp]
+            );
+        });
+    }
+
+    public function transitionState(
+        string $workerId,
+        WorkerState $newState,
+        Carbon $transitionTime,
+    ): void {
+        $workerKey = $this->store->key('worker', $workerId);
+        $ttl = $this->store->getTtl('raw');
+
+        // Check if worker exists
+        $existing = $this->store->getHash($workerKey);
+        if (empty($existing)) {
+            return;
+        }
+
+        $this->store->setHash($workerKey, [
+            'state' => $newState->value,
+            'last_state_change' => $transitionTime->timestamp,
+        ]);
+
+        // Refresh TTL on state transition
+        $this->store->expire($workerKey, $ttl);
+    }
+
+    public function getWorker(string $workerId): ?WorkerHeartbeat
+    {
+        $workerKey = $this->store->key('worker', $workerId);
+
+        /** @var array<string, string> */
+        $data = $this->store->getHash($workerKey);
+
+        if (empty($data)) {
+            return null;
+        }
+
+        return WorkerHeartbeat::fromArray($data);
+    }
+
+    /**
+     * @return Collection<int, WorkerHeartbeat>
+     */
+    public function getActiveWorkers(
+        ?string $connection = null,
+        ?string $queue = null,
+    ): Collection {
+        $indexKey = $this->store->key('workers', 'all');
+
+        // Get all worker IDs
+        /** @var array<string> */
+        $workerIds = $this->store->getSortedSetByRank($indexKey, 0, -1);
+
+        $workers = collect($workerIds)
+            ->map(fn (string $workerId) => $this->getWorker($workerId))
+            ->filter(fn (?WorkerHeartbeat $worker) => $worker !== null)
+            ->filter(fn (WorkerHeartbeat $worker) => $worker->state->isActive());
+
+        // Filter by connection if specified
+        if ($connection !== null) {
+            $workers = $workers->filter(
+                fn (WorkerHeartbeat $worker) => $worker->connection === $connection
+            );
+        }
+
+        // Filter by queue if specified
+        if ($queue !== null) {
+            $workers = $workers->filter(
+                fn (WorkerHeartbeat $worker) => $worker->queue === $queue
+            );
+        }
+
+        return $workers->values();
+    }
+
+    /**
+     * @return Collection<int, WorkerHeartbeat>
+     */
+    public function getWorkersByState(WorkerState $state): Collection
+    {
+        $indexKey = $this->store->key('workers', 'all');
+
+        /** @var array<string> */
+        $workerIds = $this->store->getSortedSetByRank($indexKey, 0, -1);
+
+        return collect($workerIds)
+            ->map(fn (string $workerId) => $this->getWorker($workerId))
+            ->filter(fn (?WorkerHeartbeat $worker) => $worker !== null && $worker->state === $state)
+            ->values();
+    }
+
+    public function detectStaledWorkers(int $thresholdSeconds = 60): int
+    {
+        $indexKey = $this->store->key('workers', 'all');
+
+        $cutoff = Carbon::now()->subSeconds($thresholdSeconds)->timestamp;
+
+        // Get workers with stale heartbeats
+        /** @var array<string> */
+        $staleWorkerIds = $this->store->getSortedSetByScore($indexKey, '-inf', (string) $cutoff);
+
+        $markedAsCrashed = 0;
+
+        foreach ($staleWorkerIds as $workerId) {
+            $worker = $this->getWorker($workerId);
+
+            if ($worker === null) {
+                continue;
+            }
+
+            // Only mark as crashed if currently active
+            if ($worker->state->isActive()) {
+                $this->transitionState($workerId, WorkerState::CRASHED, Carbon::now());
+                $markedAsCrashed++;
+            }
+        }
+
+        return $markedAsCrashed;
+    }
+
+    public function removeWorker(string $workerId): void
+    {
+        $workerKey = $this->store->key('worker', $workerId);
+        $indexKey = $this->store->key('workers', 'all');
+
+        $this->store->pipeline(function ($pipe) use ($workerKey, $indexKey, $workerId) {
+            $pipe->delete($workerKey);
+            $pipe->removeFromSortedSet($indexKey, $workerId);
+        });
+    }
+
+    public function cleanup(int $olderThanSeconds): int
+    {
+        $indexKey = $this->store->key('workers', 'all');
+
+        $cutoff = Carbon::now()->subSeconds($olderThanSeconds)->timestamp;
+
+        // Get old workers
+        /** @var array<string> */
+        $oldWorkerIds = $this->store->getSortedSetByScore($indexKey, '-inf', (string) $cutoff);
+
+        foreach ($oldWorkerIds as $workerId) {
+            $this->removeWorker($workerId);
+        }
+
+        return count($oldWorkerIds);
+    }
+}

--- a/src/Repositories/DatabaseWorkerRepository.php
+++ b/src/Repositories/DatabaseWorkerRepository.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Repositories;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\WorkerStatsData;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+/**
+ * Database-based implementation of worker repository.
+ */
+final readonly class DatabaseWorkerRepository implements WorkerRepository
+{
+    public function __construct(
+        private DatabaseMetricsStore $store,
+    ) {}
+
+    public function registerWorker(
+        int $pid,
+        string $hostname,
+        string $connection,
+        string $queue,
+        Carbon $spawnedAt,
+    ): void {
+        $key = $this->store->key('worker', $hostname, (string) $pid);
+        $driver = $this->store->driver();
+        $ttl = $this->store->getTtl('raw');
+
+        $driver->setHash($key, [
+            'pid' => $pid,
+            'hostname' => $hostname,
+            'connection' => $connection,
+            'queue' => $queue,
+            'status' => 'idle',
+            'jobs_processed' => 0,
+            'spawned_at' => $spawnedAt->timestamp,
+            'last_activity' => Carbon::now()->timestamp,
+        ]);
+
+        // Add to active workers set with hostname:pid format
+        $activeWorkersKey = $this->store->key('active_workers');
+        $driver->addToSet($activeWorkersKey, [$hostname.':'.$pid]);
+
+        // Add to workers:all sorted set (score = spawned_at timestamp)
+        $indexKey = $this->store->key('workers', 'all');
+        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => $spawnedAt->timestamp]);
+
+        // Set TTL on keys
+        $driver->expire($key, $ttl);
+        $driver->expire($activeWorkersKey, $ttl);
+    }
+
+    public function updateWorkerActivity(
+        int $pid,
+        string $hostname,
+        string $status,
+        ?string $currentJob = null,
+        int $jobsProcessed = 0,
+        float $idlePercentage = 0.0,
+    ): void {
+        $key = $this->store->key('worker', $hostname, (string) $pid);
+        $driver = $this->store->driver();
+        $ttl = $this->store->getTtl('raw');
+
+        $updates = [
+            'status' => $status,
+            'last_activity' => Carbon::now()->timestamp,
+        ];
+
+        if ($currentJob !== null) {
+            $updates['current_job'] = $currentJob;
+        }
+
+        if ($jobsProcessed > 0) {
+            $driver->incrementHashField($key, 'jobs_processed', $jobsProcessed);
+        }
+
+        if ($idlePercentage > 0.0) {
+            $updates['idle_percentage'] = (string) $idlePercentage;
+        }
+
+        $driver->setHash($key, $updates);
+
+        // Update the sorted set score to current time for activity tracking
+        $indexKey = $this->store->key('workers', 'all');
+        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => Carbon::now()->timestamp]);
+
+        // Refresh TTL on update
+        $driver->expire($key, $ttl);
+    }
+
+    public function unregisterWorker(int $pid, string $hostname): void
+    {
+        $key = $this->store->key('worker', $hostname, (string) $pid);
+        $driver = $this->store->driver();
+
+        $driver->delete($key);
+        $driver->removeFromSet($this->store->key('active_workers'), [$hostname.':'.$pid]);
+        $driver->removeFromSortedSet($this->store->key('workers', 'all'), $hostname.':'.$pid);
+    }
+
+    public function getWorkerStats(int $pid, string $hostname): ?WorkerStatsData
+    {
+        $key = $this->store->key('worker', $hostname, (string) $pid);
+        $data = $this->store->driver()->getHash($key);
+
+        if (empty($data)) {
+            return null;
+        }
+
+        return $this->buildWorkerStats($data);
+    }
+
+    /**
+     * @return array<int, WorkerStatsData>
+     */
+    public function getActiveWorkers(?string $connection = null, ?string $queue = null): array
+    {
+        $driver = $this->store->driver();
+        $activeWorkersKey = $this->store->key('active_workers');
+
+        /** @var array<int, string> $members */
+        $members = $driver->getSetMembers($activeWorkersKey);
+
+        $workers = [];
+        foreach ($members as $member) {
+            $parts = explode(':', $member, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            [$memberHostname, $memberPid] = $parts;
+            $workerKey = $this->store->key('worker', $memberHostname, $memberPid);
+
+            /** @var array<string, mixed> $data */
+            $data = $driver->getHash($workerKey);
+
+            if (empty($data)) {
+                continue;
+            }
+
+            // Skip workers that are stopped, crashed, or unknown
+            $status = $data['status'] ?? 'unknown';
+            if (! in_array($status, ['idle', 'busy', 'paused'], true)) {
+                continue;
+            }
+
+            // Skip sync workers - they are not real persistent workers
+            $workerConnection = $data['connection'] ?? 'unknown';
+            if ($workerConnection === 'sync') {
+                continue;
+            }
+
+            $stats = $this->buildWorkerStats($data);
+
+            // Filter by connection if specified
+            if ($connection !== null && $stats->connection !== $connection) {
+                continue;
+            }
+
+            // Filter by queue if specified
+            if ($queue !== null && $stats->queue !== $queue) {
+                continue;
+            }
+
+            $workers[] = $stats;
+        }
+
+        return $workers;
+    }
+
+    public function countActiveWorkers(string $connection, string $queue): int
+    {
+        return count($this->getActiveWorkers($connection, $queue));
+    }
+
+    public function cleanupStaleWorkers(int $olderThanSeconds): int
+    {
+        $driver = $this->store->driver();
+        $indexKey = $this->store->key('workers', 'all');
+
+        // Calculate cutoff timestamp
+        $cutoff = Carbon::now()->subSeconds($olderThanSeconds)->timestamp;
+
+        // Get workers with stale timestamps using sorted set score
+        /** @var array<int, string> $staleMembers */
+        $staleMembers = $driver->getSortedSetByScore($indexKey, '-inf', (string) $cutoff);
+
+        $deleted = 0;
+
+        foreach ($staleMembers as $member) {
+            $parts = explode(':', $member, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            [$memberHostname, $memberPid] = $parts;
+            $workerKey = $this->store->key('worker', $memberHostname, $memberPid);
+
+            // Delete worker hash, remove from index and active set
+            $driver->delete($workerKey);
+            $driver->removeFromSortedSet($indexKey, $member);
+            $driver->removeFromSet($this->store->key('active_workers'), [$member]);
+            $deleted++;
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Build a WorkerStatsData from raw hash data.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function buildWorkerStats(array $data): WorkerStatsData
+    {
+        return WorkerStatsData::fromArray([
+            'pid' => (int) ($data['pid'] ?? 0),
+            'hostname' => $data['hostname'] ?? 'unknown',
+            'connection' => $data['connection'] ?? 'default',
+            'queue' => $data['queue'] ?? 'default',
+            'status' => $data['status'] ?? 'idle',
+            'jobs_processed' => (int) ($data['jobs_processed'] ?? 0),
+            'current_job' => $data['current_job'] ?? null,
+            'idle_percentage' => (float) ($data['idle_percentage'] ?? 0.0),
+            'spawned_at' => isset($data['spawned_at'])
+                ? Carbon::createFromTimestamp((int) $data['spawned_at'])->toIso8601String()
+                : null,
+            'last_heartbeat' => $data['last_heartbeat'] ?? null,
+            'is_horizon_worker' => (bool) ($data['is_horizon_worker'] ?? false),
+        ]);
+    }
+}

--- a/src/Repositories/DatabaseWorkerRepository.php
+++ b/src/Repositories/DatabaseWorkerRepository.php
@@ -46,7 +46,7 @@ final readonly class DatabaseWorkerRepository implements WorkerRepository
 
         // Add to workers:all sorted set (score = spawned_at timestamp)
         $indexKey = $this->store->key('workers', 'all');
-        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => $spawnedAt->timestamp]);
+        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => (int) $spawnedAt->timestamp]);
 
         // Set TTL on keys
         $driver->expire($key, $ttl);
@@ -86,7 +86,7 @@ final readonly class DatabaseWorkerRepository implements WorkerRepository
 
         // Update the sorted set score to current time for activity tracking
         $indexKey = $this->store->key('workers', 'all');
-        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => Carbon::now()->timestamp]);
+        $driver->addToSortedSet($indexKey, [$hostname.':'.$pid => (int) Carbon::now()->timestamp]);
 
         // Refresh TTL on update
         $driver->expire($key, $ttl);
@@ -105,6 +105,7 @@ final readonly class DatabaseWorkerRepository implements WorkerRepository
     public function getWorkerStats(int $pid, string $hostname): ?WorkerStatsData
     {
         $key = $this->store->key('worker', $hostname, (string) $pid);
+        /** @var array<string, string> $data */
         $data = $this->store->driver()->getHash($key);
 
         if (empty($data)) {
@@ -135,7 +136,7 @@ final readonly class DatabaseWorkerRepository implements WorkerRepository
             [$memberHostname, $memberPid] = $parts;
             $workerKey = $this->store->key('worker', $memberHostname, $memberPid);
 
-            /** @var array<string, mixed> $data */
+            /** @var array<string, string> $data */
             $data = $driver->getHash($workerKey);
 
             if (empty($data)) {
@@ -213,7 +214,7 @@ final readonly class DatabaseWorkerRepository implements WorkerRepository
     /**
      * Build a WorkerStatsData from raw hash data.
      *
-     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $data
      */
     private function buildWorkerStats(array $data): WorkerStatsData
     {

--- a/src/Support/DatabaseMetricsStore.php
+++ b/src/Support/DatabaseMetricsStore.php
@@ -188,16 +188,21 @@ final class DatabaseMetricsStore
     public function addToSortedSet(string $key, array $membersWithScores, ?int $ttl = null): void
     {
         $expiresAt = $ttl !== null ? now()->addSeconds($ttl) : null;
+        $now = now();
 
+        $rows = [];
         foreach ($membersWithScores as $member => $score) {
-            MetricsSortedSet::updateOrCreate(
-                ['key' => $key, 'member' => (string) $member],
-                [
-                    'score' => $score,
-                    'expires_at' => $expiresAt,
-                    'updated_at' => now(),
-                ]
-            );
+            $rows[] = [
+                'key' => $key,
+                'member' => (string) $member,
+                'score' => $score,
+                'expires_at' => $expiresAt,
+                'updated_at' => $now,
+            ];
+        }
+
+        if (! empty($rows)) {
+            MetricsSortedSet::upsert($rows, ['key', 'member'], ['score', 'expires_at', 'updated_at']);
         }
     }
 

--- a/src/Support/DatabaseMetricsStore.php
+++ b/src/Support/DatabaseMetricsStore.php
@@ -206,12 +206,19 @@ final class DatabaseMetricsStore
      */
     public function getSortedSetByScore(string $key, string $min, string $max): array
     {
-        return MetricsSortedSet::notExpired()
+        $query = MetricsSortedSet::notExpired()
             ->where('key', $key)
-            ->whereBetween('score', [(float) $min, (float) $max])
-            ->orderBy('score')
-            ->pluck('member')
-            ->all();
+            ->orderBy('score');
+
+        if ($min !== '-inf') {
+            $query->where('score', '>=', (float) $min);
+        }
+
+        if ($max !== '+inf' && $max !== 'inf') {
+            $query->where('score', '<=', (float) $max);
+        }
+
+        return $query->pluck('member')->all();
     }
 
     /**
@@ -242,17 +249,32 @@ final class DatabaseMetricsStore
 
     public function countSortedSetByScore(string $key, string $min, string $max): int
     {
-        return MetricsSortedSet::notExpired()
-            ->where('key', $key)
-            ->whereBetween('score', [(float) $min, (float) $max])
-            ->count();
+        $query = MetricsSortedSet::notExpired()->where('key', $key);
+
+        if ($min !== '-inf') {
+            $query->where('score', '>=', (float) $min);
+        }
+
+        if ($max !== '+inf' && $max !== 'inf') {
+            $query->where('score', '<=', (float) $max);
+        }
+
+        return $query->count();
     }
 
     public function removeSortedSetByScore(string $key, string $min, string $max): int
     {
-        return MetricsSortedSet::where('key', $key)
-            ->whereBetween('score', [(float) $min, (float) $max])
-            ->delete();
+        $query = MetricsSortedSet::where('key', $key);
+
+        if ($min !== '-inf') {
+            $query->where('score', '>=', (float) $min);
+        }
+
+        if ($max !== '+inf' && $max !== 'inf') {
+            $query->where('score', '<=', (float) $max);
+        }
+
+        return $query->delete();
     }
 
     public function removeSortedSetByRank(string $key, int $start, int $stop): int

--- a/src/Support/DatabaseMetricsStore.php
+++ b/src/Support/DatabaseMetricsStore.php
@@ -16,22 +16,6 @@ use Illuminate\Support\Facades\DB;
  */
 final class DatabaseMetricsStore
 {
-    private ?string $prefix = null;
-
-    /**
-     * Get prefix (lazy loaded).
-     */
-    private function getPrefix(): string
-    {
-        if ($this->prefix === null) {
-            /** @var string $prefix */
-            $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
-            $this->prefix = $prefix;
-        }
-
-        return $this->prefix;
-    }
-
     /**
      * Build a key from segments.
      * The database driver does not prepend a prefix to keys because the table
@@ -104,11 +88,15 @@ final class DatabaseMetricsStore
             return 0;
         }
 
-        $count = 0;
-        $count += MetricsKey::whereIn('key', $keys)->delete();
-        $count += MetricsHash::whereIn('key', $keys)->delete();
-        $count += MetricsSet::whereIn('key', $keys)->delete();
-        $count += MetricsSortedSet::whereIn('key', $keys)->delete();
+        /** @var int $a */
+        $a = MetricsKey::whereIn('key', $keys)->delete();
+        /** @var int $b */
+        $b = MetricsHash::whereIn('key', $keys)->delete();
+        /** @var int $c */
+        $c = MetricsSet::whereIn('key', $keys)->delete();
+        /** @var int $d */
+        $d = MetricsSortedSet::whereIn('key', $keys)->delete();
+        $count = $a + $b + $c + $d;
 
         return $count;
     }
@@ -152,9 +140,10 @@ final class DatabaseMetricsStore
      */
     public function getHash(string $key): array
     {
+        /** @var MetricsHash|null $record */
         $record = MetricsHash::notExpired()->find($key);
 
-        return $record?->data ?? [];
+        return $record !== null ? $record->data : [];
     }
 
     public function getHashField(string $key, string $field): mixed
@@ -167,10 +156,11 @@ final class DatabaseMetricsStore
     public function incrementHashField(string $key, string $field, int|float $value): void
     {
         DB::transaction(function () use ($key, $field, $value) {
+            /** @var MetricsHash|null $record */
             $record = MetricsHash::lockForUpdate()->find($key);
 
-            $data = $record?->data ?? [];
-            $current = $data[$field] ?? 0;
+            $data = $record !== null ? $record->data : [];
+            $current = is_numeric($data[$field] ?? null) ? $data[$field] : 0;
             $data[$field] = is_float($value) ? (float) $current + $value : (int) $current + $value;
 
             MetricsHash::updateOrCreate(
@@ -223,6 +213,7 @@ final class DatabaseMetricsStore
             $query->where('score', '<=', (float) $max);
         }
 
+        /** @var array<int, string> */
         return $query->pluck('member')->all();
     }
 
@@ -249,6 +240,7 @@ final class DatabaseMetricsStore
 
         $limit = $stop - $start + 1;
 
+        /** @var array<int, string> */
         return $query->offset($start)->limit($limit)->pluck('member')->all();
     }
 
@@ -279,6 +271,7 @@ final class DatabaseMetricsStore
             $query->where('score', '<=', (float) $max);
         }
 
+        /** @var int */
         return $query->delete();
     }
 
@@ -310,6 +303,7 @@ final class DatabaseMetricsStore
             return 0;
         }
 
+        /** @var int */
         return MetricsSortedSet::where('key', $key)
             ->whereIn('member', $members)
             ->delete();
@@ -340,6 +334,7 @@ final class DatabaseMetricsStore
      */
     public function getSetMembers(string $key): array
     {
+        /** @var array<int, string> */
         return MetricsSet::where('key', $key)->pluck('member')->all();
     }
 
@@ -363,6 +358,7 @@ final class DatabaseMetricsStore
         $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
         $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
 
+        /** @var array<int, string> */
         return MetricsKey::notExpired()
             ->where('key', 'like', $sqlPattern)
             ->pluck('key')
@@ -381,14 +377,15 @@ final class DatabaseMetricsStore
     /**
      * Execute operations in a database transaction.
      *
-     * @param  callable(self): void  $callback
+     * @param  callable(self): mixed  $callback
      * @return array<int, mixed>
      */
     public function transaction(callable $callback): array
     {
         $result = [];
         DB::transaction(function () use ($callback, &$result) {
-            $result = (array) $callback($this);
+            $callbackResult = $callback($this);
+            $result = is_array($callbackResult) ? $callbackResult : [];
         });
 
         return $result;

--- a/src/Support/DatabaseMetricsStore.php
+++ b/src/Support/DatabaseMetricsStore.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Support;
+
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Models\MetricsKey;
+use Cbox\LaravelQueueMetrics\Models\MetricsSet;
+use Cbox\LaravelQueueMetrics\Models\MetricsSortedSet;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Database-backed metrics store using Eloquent models.
+ * Provides the same public interface as RedisMetricsStore for queue metrics storage.
+ */
+final class DatabaseMetricsStore
+{
+    private ?string $prefix = null;
+
+    /**
+     * Get prefix (lazy loaded).
+     */
+    private function getPrefix(): string
+    {
+        if ($this->prefix === null) {
+            /** @var string $prefix */
+            $prefix = config('queue-metrics.storage.prefix', 'queue_metrics');
+            $this->prefix = $prefix;
+        }
+
+        return $this->prefix;
+    }
+
+    /**
+     * Build a key from segments.
+     * The database driver does not prepend a prefix to keys because the table
+     * names (e.g. queue_metrics_keys) already act as the namespace.
+     */
+    public function key(string ...$segments): string
+    {
+        return implode(':', $segments);
+    }
+
+    /**
+     * Get TTL for a given key type.
+     */
+    public function getTtl(string $type): int
+    {
+        /** @var int */
+        return config("queue-metrics.storage.ttl.{$type}", 3600);
+    }
+
+    /**
+     * Return self as driver (for StorageManager compatibility).
+     */
+    public function driver(): self
+    {
+        return $this;
+    }
+
+    /**
+     * Return self as connection (for StorageManager compatibility).
+     */
+    public function connection(): self
+    {
+        return $this;
+    }
+
+    // --- String operations ---
+
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        MetricsKey::updateOrCreate(
+            ['key' => $key],
+            [
+                'value' => is_string($value) ? $value : json_encode($value),
+                'expires_at' => $ttl !== null ? now()->addSeconds($ttl) : null,
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    public function get(string $key): mixed
+    {
+        $record = MetricsKey::notExpired()->find($key);
+
+        return $record?->value;
+    }
+
+    public function exists(string $key): bool
+    {
+        return MetricsKey::notExpired()->where('key', $key)->exists();
+    }
+
+    /**
+     * @param  array<int, string>|string  $keys
+     */
+    public function delete(array|string $keys): int
+    {
+        $keys = is_array($keys) ? $keys : [$keys];
+
+        if (empty($keys)) {
+            return 0;
+        }
+
+        $count = 0;
+        $count += MetricsKey::whereIn('key', $keys)->delete();
+        $count += MetricsHash::whereIn('key', $keys)->delete();
+        $count += MetricsSet::whereIn('key', $keys)->delete();
+        $count += MetricsSortedSet::whereIn('key', $keys)->delete();
+
+        return $count;
+    }
+
+    public function expire(string $key, int $seconds): bool
+    {
+        $expiresAt = now()->addSeconds($seconds);
+
+        $affected = 0;
+        $affected += MetricsKey::where('key', $key)->update(['expires_at' => $expiresAt]);
+        $affected += MetricsHash::where('key', $key)->update(['expires_at' => $expiresAt]);
+        $affected += MetricsSortedSet::where('key', $key)->update(['expires_at' => $expiresAt]);
+
+        return $affected > 0;
+    }
+
+    // --- Hash operations ---
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function setHash(string $key, array $data, ?int $ttl = null): void
+    {
+        DB::transaction(function () use ($key, $data, $ttl) {
+            $existing = MetricsHash::lockForUpdate()->find($key);
+            $merged = $existing ? array_merge($existing->data, $data) : $data;
+
+            MetricsHash::updateOrCreate(
+                ['key' => $key],
+                [
+                    'data' => $merged,
+                    'expires_at' => $ttl !== null ? now()->addSeconds($ttl) : ($existing?->expires_at),
+                    'updated_at' => now(),
+                ]
+            );
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getHash(string $key): array
+    {
+        $record = MetricsHash::notExpired()->find($key);
+
+        return $record?->data ?? [];
+    }
+
+    public function getHashField(string $key, string $field): mixed
+    {
+        $data = $this->getHash($key);
+
+        return $data[$field] ?? null;
+    }
+
+    public function incrementHashField(string $key, string $field, int|float $value): void
+    {
+        DB::transaction(function () use ($key, $field, $value) {
+            $record = MetricsHash::lockForUpdate()->find($key);
+
+            $data = $record?->data ?? [];
+            $current = $data[$field] ?? 0;
+            $data[$field] = is_float($value) ? (float) $current + $value : (int) $current + $value;
+
+            MetricsHash::updateOrCreate(
+                ['key' => $key],
+                ['data' => $data, 'updated_at' => now()]
+            );
+        });
+    }
+
+    // --- Sorted set operations ---
+
+    /**
+     * @param  array<string, float|int>  $membersWithScores
+     */
+    public function addToSortedSet(string $key, array $membersWithScores, ?int $ttl = null): void
+    {
+        $expiresAt = $ttl !== null ? now()->addSeconds($ttl) : null;
+
+        foreach ($membersWithScores as $member => $score) {
+            MetricsSortedSet::updateOrCreate(
+                ['key' => $key, 'member' => (string) $member],
+                [
+                    'score' => $score,
+                    'expires_at' => $expiresAt,
+                    'updated_at' => now(),
+                ]
+            );
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSortedSetByScore(string $key, string $min, string $max): array
+    {
+        return MetricsSortedSet::notExpired()
+            ->where('key', $key)
+            ->whereBetween('score', [(float) $min, (float) $max])
+            ->orderBy('score')
+            ->pluck('member')
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSortedSetByRank(string $key, int $start, int $stop): array
+    {
+        $query = MetricsSortedSet::notExpired()->where('key', $key)->orderBy('score');
+
+        if ($start < 0 || $stop < 0) {
+            $total = (clone $query)->count();
+            if ($start < 0) {
+                $start = max(0, $total + $start);
+            }
+            if ($stop < 0) {
+                $stop = $total + $stop;
+            }
+        }
+
+        if ($stop < $start) {
+            return [];
+        }
+
+        $limit = $stop - $start + 1;
+
+        return $query->offset($start)->limit($limit)->pluck('member')->all();
+    }
+
+    public function countSortedSetByScore(string $key, string $min, string $max): int
+    {
+        return MetricsSortedSet::notExpired()
+            ->where('key', $key)
+            ->whereBetween('score', [(float) $min, (float) $max])
+            ->count();
+    }
+
+    public function removeSortedSetByScore(string $key, string $min, string $max): int
+    {
+        return MetricsSortedSet::where('key', $key)
+            ->whereBetween('score', [(float) $min, (float) $max])
+            ->delete();
+    }
+
+    public function removeSortedSetByRank(string $key, int $start, int $stop): int
+    {
+        $query = MetricsSortedSet::where('key', $key)->orderBy('score');
+
+        if ($start < 0 || $stop < 0) {
+            $total = (clone $query)->count();
+            if ($start < 0) {
+                $start = max(0, $total + $start);
+            }
+            if ($stop < 0) {
+                $stop = $total + $stop;
+            }
+        }
+
+        if ($stop < $start) {
+            return 0;
+        }
+
+        $members = (clone $query)
+            ->offset($start)
+            ->limit($stop - $start + 1)
+            ->pluck('member')
+            ->all();
+
+        if (empty($members)) {
+            return 0;
+        }
+
+        return MetricsSortedSet::where('key', $key)
+            ->whereIn('member', $members)
+            ->delete();
+    }
+
+    public function removeFromSortedSet(string $key, string $member): void
+    {
+        MetricsSortedSet::where('key', $key)->where('member', $member)->delete();
+    }
+
+    // --- Set operations ---
+
+    /**
+     * @param  array<int, string>  $members
+     */
+    public function addToSet(string $key, array $members): void
+    {
+        foreach ($members as $member) {
+            MetricsSet::firstOrCreate(
+                ['key' => $key, 'member' => (string) $member],
+                ['created_at' => now()]
+            );
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSetMembers(string $key): array
+    {
+        return MetricsSet::where('key', $key)->pluck('member')->all();
+    }
+
+    /**
+     * @param  array<int, string>  $members
+     */
+    public function removeFromSet(string $key, array $members): void
+    {
+        if (! empty($members)) {
+            MetricsSet::where('key', $key)->whereIn('member', $members)->delete();
+        }
+    }
+
+    // --- Key scanning ---
+
+    /**
+     * @return array<int, string>
+     */
+    public function scanKeys(string $pattern): array
+    {
+        $escaped = str_replace(['%', '_'], ['\\%', '\\_'], $pattern);
+        $sqlPattern = str_replace(['*', '?'], ['%', '_'], $escaped);
+
+        return MetricsKey::notExpired()
+            ->where('key', 'like', $sqlPattern)
+            ->pluck('key')
+            ->all();
+    }
+
+    // --- Transaction/Pipeline ---
+
+    public function pipeline(callable $callback): void
+    {
+        DB::transaction(function () use ($callback) {
+            $callback($this);
+        });
+    }
+
+    /**
+     * Execute operations in a database transaction.
+     *
+     * @param  callable(self): void  $callback
+     * @return array<int, mixed>
+     */
+    public function transaction(callable $callback): array
+    {
+        $result = [];
+        DB::transaction(function () use ($callback, &$result) {
+            $result = (array) $callback($this);
+        });
+
+        return $result;
+    }
+
+    // --- Lua script replacement (no-op for database) ---
+
+    /**
+     * No-op for database driver. Lua scripts are Redis-specific.
+     *
+     * @param  mixed  ...$args
+     */
+    public function eval(string $script, int $numKeys, ...$args): mixed
+    {
+        return null;
+    }
+
+    /**
+     * No-op for database driver. Raw Redis commands are not applicable.
+     *
+     * @param  array<int, mixed>  $parameters
+     */
+    public function command(string $method, array $parameters = []): mixed
+    {
+        return null;
+    }
+}

--- a/src/Support/DatabaseMetricsStore.php
+++ b/src/Support/DatabaseMetricsStore.php
@@ -170,6 +170,31 @@ final class DatabaseMetricsStore
         });
     }
 
+    /**
+     * Increment multiple hash fields atomically in a single transaction.
+     *
+     * @param  array<string, int|float>  $increments  Field => increment value pairs
+     */
+    public function incrementHashFields(string $key, array $increments): void
+    {
+        DB::transaction(function () use ($key, $increments) {
+            /** @var MetricsHash|null $record */
+            $record = MetricsHash::lockForUpdate()->find($key);
+
+            $data = $record !== null ? $record->data : [];
+
+            foreach ($increments as $field => $value) {
+                $current = is_numeric($data[$field] ?? null) ? $data[$field] : 0;
+                $data[$field] = is_float($value) ? (float) $current + $value : (int) $current + $value;
+            }
+
+            MetricsHash::updateOrCreate(
+                ['key' => $key],
+                ['data' => $data, 'updated_at' => now()]
+            );
+        });
+    }
+
     // --- Sorted set operations ---
 
     /**

--- a/src/Support/HeartbeatThrottleCache.php
+++ b/src/Support/HeartbeatThrottleCache.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Support;
+
+/**
+ * In-memory throttle cache for database heartbeat writes.
+ *
+ * Prevents excessive database writes when the worker state has not changed.
+ * Extracted as a standalone class because PHP readonly classes cannot contain
+ * static properties.
+ *
+ * @internal
+ */
+final class HeartbeatThrottleCache
+{
+    private const THROTTLE_SECONDS = 10;
+
+    /** @var array<string, int> Last heartbeat write timestamp per worker ID */
+    private static array $lastWrite = [];
+
+    /** @var array<string, string> Last known state value per worker ID */
+    private static array $lastState = [];
+
+    /**
+     * Determine whether the heartbeat write should be skipped.
+     */
+    public static function shouldSkip(string $workerId, string $stateValue, int $currentTimestamp): bool
+    {
+        $lastWrite = self::$lastWrite[$workerId] ?? 0;
+        $lastKnownState = self::$lastState[$workerId] ?? null;
+        $timeSinceWrite = $currentTimestamp - $lastWrite;
+
+        return $timeSinceWrite < self::THROTTLE_SECONDS && $lastKnownState === $stateValue;
+    }
+
+    /**
+     * Record that a heartbeat was written for the given worker.
+     */
+    public static function record(string $workerId, string $stateValue, int $currentTimestamp): void
+    {
+        self::$lastWrite[$workerId] = $currentTimestamp;
+        self::$lastState[$workerId] = $stateValue;
+    }
+
+    /**
+     * Reset the in-memory throttle cache.
+     *
+     * Intended for use in tests to ensure a clean state between test cases.
+     */
+    public static function reset(): void
+    {
+        self::$lastWrite = [];
+        self::$lastState = [];
+    }
+}

--- a/tests/Feature/Console/CleanupDatabaseCommandTest.php
+++ b/tests/Feature/Console/CleanupDatabaseCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Models\MetricsHash;
+use Cbox\LaravelQueueMetrics\Models\MetricsKey;
+use Cbox\LaravelQueueMetrics\Models\MetricsSortedSet;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+});
+
+test('cleanup removes expired keys', function () {
+    MetricsKey::create(['key' => 'old', 'value' => 'x', 'expires_at' => now()->subHour(), 'updated_at' => now()]);
+    MetricsKey::create(['key' => 'fresh', 'value' => 'x', 'expires_at' => now()->addHour(), 'updated_at' => now()]);
+
+    $this->artisan('queue-metrics:cleanup-database')->assertExitCode(0);
+
+    expect(MetricsKey::count())->toBe(1);
+    expect(MetricsKey::first()->key)->toBe('fresh');
+});
+
+test('cleanup removes expired hashes', function () {
+    MetricsHash::create(['key' => 'old', 'data' => [], 'expires_at' => now()->subHour(), 'updated_at' => now()]);
+
+    $this->artisan('queue-metrics:cleanup-database')->assertExitCode(0);
+
+    expect(MetricsHash::count())->toBe(0);
+});
+
+test('cleanup trims sorted sets exceeding max samples', function () {
+    $max = config('queue-metrics.storage.max_samples_per_key', 1000);
+
+    for ($i = 0; $i < $max + 50; $i++) {
+        MetricsSortedSet::create([
+            'key' => 'samples:test',
+            'member' => "m-{$i}",
+            'score' => $i,
+            'updated_at' => now(),
+        ]);
+    }
+
+    $this->artisan('queue-metrics:cleanup-database')->assertExitCode(0);
+
+    expect(MetricsSortedSet::where('key', 'samples:test')->count())->toBe($max);
+});
+
+test('cleanup does nothing when no expired data', function () {
+    MetricsKey::create(['key' => 'valid', 'value' => 'x', 'expires_at' => now()->addDay(), 'updated_at' => now()]);
+
+    $this->artisan('queue-metrics:cleanup-database')->assertExitCode(0);
+
+    expect(MetricsKey::count())->toBe(1);
+});

--- a/tests/Feature/DatabaseDriverIntegrationTest.php
+++ b/tests/Feature/DatabaseDriverIntegrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\BaselineRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseBaselineRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerRepository;
+use Cbox\LaravelQueueMetrics\Repositories\RedisWorkerRepository;
+
+test('database driver binds database repositories', function () {
+    config()->set('queue-metrics.storage.driver', 'database');
+    config()->set('queue-metrics.repositories', [
+        JobMetricsRepository::class => null,
+        QueueMetricsRepository::class => null,
+        WorkerRepository::class => null,
+        BaselineRepository::class => null,
+        WorkerHeartbeatRepository::class => null,
+    ]);
+
+    // Force re-registration
+    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider->packageRegistered();
+
+    expect(app(JobMetricsRepository::class))->toBeInstanceOf(DatabaseJobMetricsRepository::class)
+        ->and(app(QueueMetricsRepository::class))->toBeInstanceOf(DatabaseQueueMetricsRepository::class)
+        ->and(app(WorkerRepository::class))->toBeInstanceOf(DatabaseWorkerRepository::class)
+        ->and(app(BaselineRepository::class))->toBeInstanceOf(DatabaseBaselineRepository::class)
+        ->and(app(WorkerHeartbeatRepository::class))->toBeInstanceOf(DatabaseWorkerHeartbeatRepository::class);
+});
+
+test('explicit repository override takes precedence over driver', function () {
+    config()->set('queue-metrics.storage.driver', 'database');
+    config()->set('queue-metrics.repositories', [
+        JobMetricsRepository::class => null,
+        QueueMetricsRepository::class => null,
+        WorkerRepository::class => RedisWorkerRepository::class,
+        BaselineRepository::class => null,
+        WorkerHeartbeatRepository::class => null,
+    ]);
+
+    // Force re-registration
+    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider->packageRegistered();
+
+    expect(app(WorkerRepository::class))->toBeInstanceOf(RedisWorkerRepository::class);
+});
+
+test('redis driver binds redis repositories by default', function () {
+    config()->set('queue-metrics.storage.driver', 'redis');
+    config()->set('queue-metrics.repositories', [
+        JobMetricsRepository::class => null,
+        WorkerRepository::class => null,
+    ]);
+
+    // Force re-registration
+    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider->packageRegistered();
+
+    expect(app(WorkerRepository::class))->toBeInstanceOf(RedisWorkerRepository::class);
+});

--- a/tests/Feature/DatabaseDriverIntegrationTest.php
+++ b/tests/Feature/DatabaseDriverIntegrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\BaselineRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
@@ -25,7 +26,7 @@ test('database driver binds database repositories', function () {
     ]);
 
     // Force re-registration
-    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider = new LaravelQueueMetricsServiceProvider(app());
     $provider->packageRegistered();
 
     expect(app(JobMetricsRepository::class))->toBeInstanceOf(DatabaseJobMetricsRepository::class)
@@ -46,7 +47,7 @@ test('explicit repository override takes precedence over driver', function () {
     ]);
 
     // Force re-registration
-    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider = new LaravelQueueMetricsServiceProvider(app());
     $provider->packageRegistered();
 
     expect(app(WorkerRepository::class))->toBeInstanceOf(RedisWorkerRepository::class);
@@ -60,7 +61,7 @@ test('redis driver binds redis repositories by default', function () {
     ]);
 
     // Force re-registration
-    $provider = new \Cbox\LaravelQueueMetrics\LaravelQueueMetricsServiceProvider(app());
+    $provider = new LaravelQueueMetricsServiceProvider(app());
     $provider->packageRegistered();
 
     expect(app(WorkerRepository::class))->toBeInstanceOf(RedisWorkerRepository::class);

--- a/tests/Feature/Repositories/DatabaseBaselineRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseBaselineRepositoryTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\BaselineData;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseBaselineRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+    $this->repo = new DatabaseBaselineRepository($this->store);
+});
+
+// --- storeBaseline and getBaseline round-trip ---
+
+test('storeBaseline and getBaseline round-trip for aggregate baseline', function () {
+    $baseline = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: Carbon::parse('2025-06-01 12:00:00'),
+    );
+
+    $this->repo->storeBaseline($baseline);
+
+    $retrieved = $this->repo->getBaseline('redis', 'default');
+
+    expect($retrieved)->not->toBeNull();
+    expect($retrieved->connection)->toBe('redis');
+    expect($retrieved->queue)->toBe('default');
+    expect($retrieved->jobClass)->toBe('');
+    expect($retrieved->cpuPercentPerJob)->toBe(2.5);
+    expect($retrieved->memoryMbPerJob)->toBe(64.0);
+    expect($retrieved->avgDurationMs)->toBe(150.0);
+    expect($retrieved->sampleCount)->toBe(100);
+    expect($retrieved->confidenceScore)->toBe(0.85);
+    expect($retrieved->calculatedAt->toDateTimeString())->toBe('2025-06-01 12:00:00');
+});
+
+test('getBaseline returns null when no baseline exists', function () {
+    expect($this->repo->getBaseline('redis', 'default'))->toBeNull();
+});
+
+// --- storeBaseline with jobClass and getJobClassBaseline ---
+
+test('storeBaseline with jobClass and getJobClassBaseline round-trip', function () {
+    $baseline = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: 'App\\Jobs\\SendEmail',
+        cpuPercentPerJob: 3.0,
+        memoryMbPerJob: 128.0,
+        avgDurationMs: 200.0,
+        sampleCount: 50,
+        confidenceScore: 0.75,
+        calculatedAt: Carbon::parse('2025-06-01 12:00:00'),
+    );
+
+    $this->repo->storeBaseline($baseline);
+
+    $retrieved = $this->repo->getJobClassBaseline('redis', 'default', 'App\\Jobs\\SendEmail');
+
+    expect($retrieved)->not->toBeNull();
+    expect($retrieved->connection)->toBe('redis');
+    expect($retrieved->queue)->toBe('default');
+    expect($retrieved->jobClass)->toBe('App\\Jobs\\SendEmail');
+    expect($retrieved->cpuPercentPerJob)->toBe(3.0);
+    expect($retrieved->memoryMbPerJob)->toBe(128.0);
+    expect($retrieved->avgDurationMs)->toBe(200.0);
+    expect($retrieved->sampleCount)->toBe(50);
+    expect($retrieved->confidenceScore)->toBe(0.75);
+});
+
+test('getJobClassBaseline returns null when no baseline exists', function () {
+    expect($this->repo->getJobClassBaseline('redis', 'default', 'App\\Jobs\\Nope'))->toBeNull();
+});
+
+// --- getBaselines with multiple queue pairs ---
+
+test('getBaselines returns baselines for multiple queue pairs', function () {
+    $baseline1 = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    $baseline2 = new BaselineData(
+        connection: 'sqs',
+        queue: 'emails',
+        jobClass: '',
+        cpuPercentPerJob: 5.0,
+        memoryMbPerJob: 256.0,
+        avgDurationMs: 500.0,
+        sampleCount: 200,
+        confidenceScore: 0.9,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($baseline1);
+    $this->repo->storeBaseline($baseline2);
+
+    $result = $this->repo->getBaselines([
+        ['connection' => 'redis', 'queue' => 'default'],
+        ['connection' => 'sqs', 'queue' => 'emails'],
+        ['connection' => 'redis', 'queue' => 'nonexistent'],
+    ]);
+
+    expect($result)->toHaveCount(2);
+    expect($result)->toHaveKey('redis:default');
+    expect($result)->toHaveKey('sqs:emails');
+    expect($result['redis:default']->cpuPercentPerJob)->toBe(2.5);
+    expect($result['sqs:emails']->cpuPercentPerJob)->toBe(5.0);
+});
+
+test('getBaselines returns empty array for empty input', function () {
+    expect($this->repo->getBaselines([]))->toBe([]);
+});
+
+// --- getJobClassBaselines ---
+
+test('getJobClassBaselines returns per-class baselines excluding aggregate', function () {
+    // Store aggregate baseline
+    $aggregate = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    // Store per-class baselines
+    $class1 = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: 'App\\Jobs\\SendEmail',
+        cpuPercentPerJob: 3.0,
+        memoryMbPerJob: 128.0,
+        avgDurationMs: 200.0,
+        sampleCount: 50,
+        confidenceScore: 0.75,
+        calculatedAt: now(),
+    );
+
+    $class2 = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: 'App\\Jobs\\ProcessOrder',
+        cpuPercentPerJob: 5.0,
+        memoryMbPerJob: 256.0,
+        avgDurationMs: 500.0,
+        sampleCount: 75,
+        confidenceScore: 0.8,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($aggregate);
+    $this->repo->storeBaseline($class1);
+    $this->repo->storeBaseline($class2);
+
+    $baselines = $this->repo->getJobClassBaselines('redis', 'default');
+
+    expect($baselines)->toHaveCount(2);
+
+    $jobClasses = array_map(fn (BaselineData $b) => $b->jobClass, $baselines);
+    expect($jobClasses)->toContain('App\\Jobs\\SendEmail');
+    expect($jobClasses)->toContain('App\\Jobs\\ProcessOrder');
+    expect($jobClasses)->not->toContain('');
+});
+
+test('getJobClassBaselines returns empty array when no per-class baselines exist', function () {
+    // Only store aggregate
+    $aggregate = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+    $this->repo->storeBaseline($aggregate);
+
+    $baselines = $this->repo->getJobClassBaselines('redis', 'default');
+    expect($baselines)->toBe([]);
+});
+
+// --- hasRecentBaseline ---
+
+test('hasRecentBaseline returns true when baseline is recent', function () {
+    $baseline = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($baseline);
+
+    expect($this->repo->hasRecentBaseline('redis', 'default'))->toBeTrue();
+});
+
+test('hasRecentBaseline returns false when baseline is old', function () {
+    $baseline = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now()->subDays(2),
+    );
+
+    $this->repo->storeBaseline($baseline);
+
+    expect($this->repo->hasRecentBaseline('redis', 'default', 86400))->toBeFalse();
+});
+
+test('hasRecentBaseline returns false when no baseline exists', function () {
+    expect($this->repo->hasRecentBaseline('redis', 'default'))->toBeFalse();
+});
+
+// --- deleteBaseline ---
+
+test('deleteBaseline removes all baselines for a queue', function () {
+    // Store aggregate
+    $aggregate = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    // Store per-class
+    $perClass = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: 'App\\Jobs\\SendEmail',
+        cpuPercentPerJob: 3.0,
+        memoryMbPerJob: 128.0,
+        avgDurationMs: 200.0,
+        sampleCount: 50,
+        confidenceScore: 0.75,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($aggregate);
+    $this->repo->storeBaseline($perClass);
+
+    // Verify they exist
+    expect($this->repo->getBaseline('redis', 'default'))->not->toBeNull();
+    expect($this->repo->getJobClassBaseline('redis', 'default', 'App\\Jobs\\SendEmail'))->not->toBeNull();
+
+    $this->repo->deleteBaseline('redis', 'default');
+
+    expect($this->repo->getBaseline('redis', 'default'))->toBeNull();
+    expect($this->repo->getJobClassBaseline('redis', 'default', 'App\\Jobs\\SendEmail'))->toBeNull();
+});
+
+test('deleteBaseline does not affect other queues', function () {
+    $baseline1 = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    $baseline2 = new BaselineData(
+        connection: 'redis',
+        queue: 'emails',
+        jobClass: '',
+        cpuPercentPerJob: 5.0,
+        memoryMbPerJob: 256.0,
+        avgDurationMs: 500.0,
+        sampleCount: 200,
+        confidenceScore: 0.9,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($baseline1);
+    $this->repo->storeBaseline($baseline2);
+
+    $this->repo->deleteBaseline('redis', 'default');
+
+    expect($this->repo->getBaseline('redis', 'default'))->toBeNull();
+    expect($this->repo->getBaseline('redis', 'emails'))->not->toBeNull();
+});
+
+// --- cleanup ---
+
+test('cleanup removes old baselines and returns count', function () {
+    // Store old baseline
+    $old = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now()->subDays(10),
+    );
+
+    // Store recent baseline
+    $recent = new BaselineData(
+        connection: 'sqs',
+        queue: 'emails',
+        jobClass: '',
+        cpuPercentPerJob: 5.0,
+        memoryMbPerJob: 256.0,
+        avgDurationMs: 500.0,
+        sampleCount: 200,
+        confidenceScore: 0.9,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($old);
+    $this->repo->storeBaseline($recent);
+
+    $deleted = $this->repo->cleanup(86400); // Older than 1 day
+
+    expect($deleted)->toBe(1);
+    expect($this->repo->getBaseline('redis', 'default'))->toBeNull();
+    expect($this->repo->getBaseline('sqs', 'emails'))->not->toBeNull();
+});
+
+test('cleanup returns zero when nothing to clean', function () {
+    $baseline = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: '',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now(),
+    );
+
+    $this->repo->storeBaseline($baseline);
+
+    expect($this->repo->cleanup(86400))->toBe(0);
+});
+
+test('cleanup also removes old per-class baselines', function () {
+    $oldPerClass = new BaselineData(
+        connection: 'redis',
+        queue: 'default',
+        jobClass: 'App\\Jobs\\OldJob',
+        cpuPercentPerJob: 2.5,
+        memoryMbPerJob: 64.0,
+        avgDurationMs: 150.0,
+        sampleCount: 100,
+        confidenceScore: 0.85,
+        calculatedAt: now()->subDays(10),
+    );
+
+    $this->repo->storeBaseline($oldPerClass);
+
+    $deleted = $this->repo->cleanup(86400);
+
+    expect($deleted)->toBe(1);
+    expect($this->repo->getJobClassBaseline('redis', 'default', 'App\\Jobs\\OldJob'))->toBeNull();
+});

--- a/tests/Feature/Repositories/DatabaseJobMetricsRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseJobMetricsRepositoryTest.php
@@ -1,0 +1,434 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseJobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+    $this->repo = new DatabaseJobMetricsRepository($this->store);
+});
+
+// --- recordStart ---
+
+test('recordStart stores job data and increments total_queued', function () {
+    $this->repo->recordStart('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $metrics = $this->repo->getMetrics('App\\Jobs\\SendEmail', 'redis', 'default');
+    expect($metrics['total_processed'])->toBe(0);
+
+    // Verify total_queued was incremented
+    $metricsKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($metricsKey);
+    expect($data['total_queued'])->toBe(1);
+
+    // Verify job hash was stored
+    $jobData = $this->store->getHash('job:job-1');
+    expect($jobData['job_class'])->toBe('App\\Jobs\\SendEmail');
+    expect($jobData['connection'])->toBe('redis');
+    expect($jobData['queue'])->toBe('default');
+});
+
+test('recordStart registers job in discovery set', function () {
+    $this->repo->recordStart('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $jobs = $this->repo->listJobs();
+    expect($jobs)->toHaveCount(1);
+    expect($jobs[0]['connection'])->toBe('redis');
+    expect($jobs[0]['queue'])->toBe('default');
+    expect($jobs[0]['jobClass'])->toBe('App\\Jobs\\SendEmail');
+});
+
+test('recordStart registers queue in discovery set', function () {
+    $this->repo->recordStart('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $members = $this->store->getSetMembers('discovery:queues');
+    expect($members)->toContain('redis:default');
+});
+
+// --- recordCompletion ---
+
+test('recordCompletion stores metrics and samples', function () {
+    $this->repo->recordCompletion(
+        jobId: 'job-1',
+        jobClass: 'App\\Jobs\\SendEmail',
+        connection: 'redis',
+        queue: 'default',
+        durationMs: 150.0,
+        memoryMb: 32.5,
+        cpuTimeMs: 45.0,
+        completedAt: now(),
+    );
+
+    $metrics = $this->repo->getMetrics('App\\Jobs\\SendEmail', 'redis', 'default');
+    expect($metrics['total_processed'])->toBe(1);
+    expect((float) $metrics['total_duration_ms'])->toBe(150.0);
+    expect((float) $metrics['total_memory_mb'])->toBe(32.5);
+    expect((float) $metrics['total_cpu_time_ms'])->toBe(45.0);
+
+    $durations = $this->repo->getDurationSamples('App\\Jobs\\SendEmail', 'redis', 'default', 100);
+    expect($durations)->toHaveCount(1);
+    expect($durations[0])->toBe(150.0);
+});
+
+test('recordCompletion accumulates metrics across multiple calls', function () {
+    $this->repo->recordCompletion('j1', 'App\\Jobs\\SendEmail', 'redis', 'default', 100.0, 10.0, 5.0, now());
+    $this->repo->recordCompletion('j2', 'App\\Jobs\\SendEmail', 'redis', 'default', 200.0, 20.0, 10.0, now());
+
+    $metrics = $this->repo->getMetrics('App\\Jobs\\SendEmail', 'redis', 'default');
+    expect($metrics['total_processed'])->toBe(2);
+    expect((float) $metrics['total_duration_ms'])->toBe(300.0);
+    expect((float) $metrics['total_memory_mb'])->toBe(30.0);
+    expect((float) $metrics['total_cpu_time_ms'])->toBe(15.0);
+});
+
+test('recordCompletion cleans up job tracking key', function () {
+    $this->repo->recordStart('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $this->repo->recordCompletion('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', 150.0, 32.5, 45.0, now());
+
+    $jobData = $this->store->getHash('job:job-1');
+    expect($jobData)->toBe([]);
+});
+
+test('recordCompletion stores hostname metrics when provided', function () {
+    $this->repo->recordCompletion(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        150.0, 32.5, 45.0, now(), 'prod-01'
+    );
+
+    $hostnameMetrics = $this->repo->getHostnameJobMetrics('prod-01');
+    expect($hostnameMetrics)->not->toBeEmpty();
+
+    $firstKey = array_key_first($hostnameMetrics);
+    expect($hostnameMetrics[$firstKey]['total_processed'])->toBe(1);
+    expect($hostnameMetrics[$firstKey]['total_duration_ms'])->toBe(150.0);
+});
+
+// --- recordFailure ---
+
+test('recordFailure increments failure counter and stores exception', function () {
+    $this->repo->recordFailure(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException: Something went wrong', now()
+    );
+
+    $metrics = $this->repo->getMetrics('App\\Jobs\\SendEmail', 'redis', 'default');
+    expect($metrics['total_failed'])->toBe(1);
+    expect($metrics['last_exception'])->toBe('RuntimeException: Something went wrong');
+    expect($metrics['last_failed_at'])->not->toBeNull();
+});
+
+test('recordFailure stores hostname failure metrics when provided', function () {
+    $this->repo->recordFailure(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException: fail', now(), 'prod-01'
+    );
+
+    $hostnameMetrics = $this->repo->getHostnameJobMetrics('prod-01');
+    expect($hostnameMetrics)->not->toBeEmpty();
+
+    $firstKey = array_key_first($hostnameMetrics);
+    expect($hostnameMetrics[$firstKey]['total_failed'])->toBe(1);
+});
+
+test('recordFailure cleans up job tracking key', function () {
+    $this->repo->recordStart('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $this->repo->recordFailure(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException: fail', now()
+    );
+
+    $jobData = $this->store->getHash('job:job-1');
+    expect($jobData)->toBe([]);
+});
+
+test('recordFailure truncates long exception messages', function () {
+    $longException = str_repeat('x', 2000);
+    $this->repo->recordFailure(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        $longException, now()
+    );
+
+    $metrics = $this->repo->getMetrics('App\\Jobs\\SendEmail', 'redis', 'default');
+    expect(strlen($metrics['last_exception']))->toBeLessThanOrEqual(1000);
+});
+
+// --- getDurationSamples ---
+
+test('getDurationSamples returns parsed values in chronological order', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100.0, 10.0, 5.0, now()->subSeconds(3));
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 200.0, 20.0, 10.0, now()->subSeconds(2));
+    $this->repo->recordCompletion('j3', 'Job', 'redis', 'default', 300.0, 30.0, 15.0, now()->subSeconds(1));
+
+    $durations = $this->repo->getDurationSamples('Job', 'redis', 'default', 100);
+    expect($durations)->toBe([100.0, 200.0, 300.0]);
+});
+
+test('getDurationSamples respects limit parameter', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100.0, 10.0, 5.0, now()->subSeconds(3));
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 200.0, 20.0, 10.0, now()->subSeconds(2));
+    $this->repo->recordCompletion('j3', 'Job', 'redis', 'default', 300.0, 30.0, 15.0, now()->subSeconds(1));
+
+    $durations = $this->repo->getDurationSamples('Job', 'redis', 'default', 2);
+    expect($durations)->toHaveCount(2);
+    expect($durations)->toBe([200.0, 300.0]);
+});
+
+test('getDurationSamples returns empty array when no samples', function () {
+    $durations = $this->repo->getDurationSamples('Job', 'redis', 'default', 100);
+    expect($durations)->toBe([]);
+});
+
+// --- getMemorySamples ---
+
+test('getMemorySamples returns parsed values', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100.0, 32.5, 5.0, now()->subSeconds(2));
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 200.0, 64.0, 10.0, now()->subSeconds(1));
+
+    $samples = $this->repo->getMemorySamples('Job', 'redis', 'default', 100);
+    expect($samples)->toBe([32.5, 64.0]);
+});
+
+// --- getCpuTimeSamples ---
+
+test('getCpuTimeSamples returns parsed values', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100.0, 10.0, 45.0, now()->subSeconds(2));
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 200.0, 20.0, 90.0, now()->subSeconds(1));
+
+    $samples = $this->repo->getCpuTimeSamples('Job', 'redis', 'default', 100);
+    expect($samples)->toBe([45.0, 90.0]);
+});
+
+// --- getThroughput ---
+
+test('getThroughput counts completions within window', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100, 10, 5, now());
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 100, 10, 5, now());
+    $this->repo->recordCompletion('j3', 'Job', 'redis', 'default', 100, 10, 5, now()->subHours(2));
+
+    expect($this->repo->getThroughput('Job', 'redis', 'default', 3600))->toBe(2);
+});
+
+test('getThroughput returns zero when no completions', function () {
+    expect($this->repo->getThroughput('Job', 'redis', 'default', 3600))->toBe(0);
+});
+
+test('getThroughput returns all within large window', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100, 10, 5, now()->subHours(2));
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 100, 10, 5, now()->subHours(1));
+    $this->repo->recordCompletion('j3', 'Job', 'redis', 'default', 100, 10, 5, now());
+
+    expect($this->repo->getThroughput('Job', 'redis', 'default', 86400))->toBe(3);
+});
+
+// --- getAverageDurationInWindow ---
+
+test('getAverageDurationInWindow calculates average for completions within window', function () {
+    $this->repo->recordCompletion('j1', 'Job', 'redis', 'default', 100.0, 10, 5, now());
+    $this->repo->recordCompletion('j2', 'Job', 'redis', 'default', 200.0, 10, 5, now());
+    $this->repo->recordCompletion('j3', 'Job', 'redis', 'default', 900.0, 10, 5, now()->subHours(2));
+
+    $avg = $this->repo->getAverageDurationInWindow('Job', 'redis', 'default', 3600);
+    expect($avg)->toBe(150.0);
+});
+
+test('getAverageDurationInWindow returns zero when no completions', function () {
+    expect($this->repo->getAverageDurationInWindow('Job', 'redis', 'default', 3600))->toBe(0.0);
+});
+
+// --- getHostnameJobMetrics ---
+
+test('getHostnameJobMetrics returns metrics for hostname', function () {
+    $this->repo->recordCompletion('j1', 'App\\Jobs\\A', 'redis', 'default', 100.0, 10, 5, now(), 'prod-01');
+    $this->repo->recordCompletion('j2', 'App\\Jobs\\A', 'redis', 'default', 200.0, 10, 5, now(), 'prod-01');
+    $this->repo->recordFailure('j3', 'App\\Jobs\\A', 'redis', 'default', 'Error', now(), 'prod-01');
+
+    $metrics = $this->repo->getHostnameJobMetrics('prod-01');
+    expect($metrics)->not->toBeEmpty();
+
+    $firstKey = array_key_first($metrics);
+    expect($metrics[$firstKey]['total_processed'])->toBe(2);
+    expect($metrics[$firstKey]['total_failed'])->toBe(1);
+    expect($metrics[$firstKey]['total_duration_ms'])->toBe(300.0);
+    expect($metrics[$firstKey]['failure_rate'])->toBe(33.33);
+    expect($metrics[$firstKey]['avg_duration_ms'])->toBe(150.0);
+});
+
+test('getHostnameJobMetrics returns empty array for unknown hostname', function () {
+    expect($this->repo->getHostnameJobMetrics('unknown-host'))->toBe([]);
+});
+
+// --- listJobs and markJobDiscovered ---
+
+test('listJobs returns empty array initially', function () {
+    expect($this->repo->listJobs())->toBe([]);
+});
+
+test('markJobDiscovered registers job and listJobs returns it', function () {
+    $this->repo->markJobDiscovered('redis', 'default', 'App\\Jobs\\SendEmail');
+    $this->repo->markJobDiscovered('sqs', 'emails', 'App\\Jobs\\ProcessOrder');
+
+    $jobs = $this->repo->listJobs();
+    expect($jobs)->toHaveCount(2);
+
+    $jobClasses = array_column($jobs, 'jobClass');
+    expect($jobClasses)->toContain('App\\Jobs\\SendEmail');
+    expect($jobClasses)->toContain('App\\Jobs\\ProcessOrder');
+});
+
+test('markJobDiscovered does not create duplicates', function () {
+    $this->repo->markJobDiscovered('redis', 'default', 'App\\Jobs\\SendEmail');
+    $this->repo->markJobDiscovered('redis', 'default', 'App\\Jobs\\SendEmail');
+
+    $jobs = $this->repo->listJobs();
+    expect($jobs)->toHaveCount(1);
+});
+
+// --- recordQueuedAt ---
+
+test('recordQueuedAt stores timestamp', function () {
+    $queuedAt = now();
+    $this->repo->recordQueuedAt('App\\Jobs\\SendEmail', 'redis', 'default', $queuedAt);
+
+    // Verify via sorted set - queued entries should exist
+    $key = $this->store->key('queued', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $members = $this->store->getSortedSetByScore($key, '-inf', '+inf');
+    expect($members)->toHaveCount(1);
+});
+
+// --- recordRetryRequested ---
+
+test('recordRetryRequested increments retry counter', function () {
+    $this->repo->recordRetryRequested('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now(), 2);
+
+    $metricsKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($metricsKey);
+    expect($data['total_retries'])->toBe(1);
+});
+
+test('recordRetryRequested stores retry event in sorted set', function () {
+    $this->repo->recordRetryRequested('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now(), 2);
+
+    $retryKey = $this->store->key('retries', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $members = $this->store->getSortedSetByScore($retryKey, '-inf', '+inf');
+    expect($members)->toHaveCount(1);
+    expect($members[0])->toContain('"job_id":"job-1"');
+});
+
+// --- recordTimeout ---
+
+test('recordTimeout increments timeout counter', function () {
+    $this->repo->recordTimeout('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', now());
+
+    $metricsKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($metricsKey);
+    expect($data['total_timeouts'])->toBe(1);
+});
+
+test('recordTimeout stores last timeout timestamp', function () {
+    $timedOutAt = now();
+    $this->repo->recordTimeout('job-1', 'App\\Jobs\\SendEmail', 'redis', 'default', $timedOutAt);
+
+    $metricsKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($metricsKey);
+    expect($data['last_timeout_at'])->toBe($timedOutAt->timestamp);
+});
+
+// --- recordException ---
+
+test('recordException increments exception counter', function () {
+    $this->repo->recordException(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException', 'Something failed', now()
+    );
+
+    $metricsKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($metricsKey);
+    expect($data['total_exceptions'])->toBe(1);
+});
+
+test('recordException tracks exception class counts', function () {
+    $this->repo->recordException(
+        'job-1', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException', 'fail 1', now()
+    );
+    $this->repo->recordException(
+        'job-2', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'RuntimeException', 'fail 2', now()
+    );
+    $this->repo->recordException(
+        'job-3', 'App\\Jobs\\SendEmail', 'redis', 'default',
+        'InvalidArgumentException', 'bad arg', now()
+    );
+
+    $exceptionsKey = $this->store->key('exceptions', 'redis', 'default', 'App\\Jobs\\SendEmail');
+    $data = $this->store->getHash($exceptionsKey);
+    expect($data['RuntimeException'])->toBe(2);
+    expect($data['InvalidArgumentException'])->toBe(1);
+});
+
+// --- cleanup ---
+
+test('cleanup removes old job metrics', function () {
+    // Create a job that was processed long ago
+    $oldKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\OldJob');
+    $this->store->setHash($oldKey, [
+        'total_processed' => 5,
+        'last_processed_at' => now()->subDays(10)->timestamp,
+    ]);
+
+    // Create a recent job
+    $recentKey = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\RecentJob');
+    $this->store->setHash($recentKey, [
+        'total_processed' => 3,
+        'last_processed_at' => now()->timestamp,
+    ]);
+
+    $deleted = $this->repo->cleanup(86400); // Older than 1 day
+
+    expect($deleted)->toBe(1);
+    expect($this->store->getHash($oldKey))->toBe([]);
+    expect($this->store->getHash($recentKey))->not->toBe([]);
+});
+
+test('cleanup returns zero when nothing to clean', function () {
+    $key = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\RecentJob');
+    $this->store->setHash($key, [
+        'total_processed' => 3,
+        'last_processed_at' => now()->timestamp,
+    ]);
+
+    $deleted = $this->repo->cleanup(86400);
+    expect($deleted)->toBe(0);
+});
+
+test('cleanup skips keys without last_processed_at', function () {
+    $key = $this->store->key('jobs', 'redis', 'default', 'App\\Jobs\\NoTimestamp');
+    $this->store->setHash($key, ['total_processed' => 1]);
+
+    $deleted = $this->repo->cleanup(86400);
+    expect($deleted)->toBe(0);
+});
+
+// --- getMetrics ---
+
+test('getMetrics returns defaults for non-existent job', function () {
+    $metrics = $this->repo->getMetrics('NonExistent', 'redis', 'default');
+
+    expect($metrics['total_processed'])->toBe(0);
+    expect($metrics['total_failed'])->toBe(0);
+    expect($metrics['total_duration_ms'])->toBe(0.0);
+    expect($metrics['total_memory_mb'])->toBe(0.0);
+    expect($metrics['total_cpu_time_ms'])->toBe(0.0);
+    expect($metrics['last_processed_at'])->toBeNull();
+    expect($metrics['last_failed_at'])->toBeNull();
+    expect($metrics['last_exception'])->toBeNull();
+});

--- a/tests/Feature/Repositories/DatabaseQueueMetricsRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseQueueMetricsRepositoryTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+    $this->repo = new DatabaseQueueMetricsRepository($this->store);
+});
+
+// --- getQueueState ---
+
+test('getQueueState returns depth info from queue driver', function () {
+    Queue::shouldReceive('connection')
+        ->with('redis')
+        ->andReturnSelf();
+
+    Queue::shouldReceive('size')
+        ->with('default')
+        ->andReturn(42);
+
+    $state = $this->repo->getQueueState('redis', 'default');
+
+    expect($state['depth'])->toBe(42);
+    expect($state['pending'])->toBe(42);
+    expect($state['scheduled'])->toBe(0);
+    expect($state['reserved'])->toBe(0);
+    expect($state['oldest_job_age'])->toBe(0);
+});
+
+// --- recordSnapshot and getLatestMetrics ---
+
+test('recordSnapshot stores snapshot and getLatestMetrics retrieves it', function () {
+    $metrics = [
+        'depth' => 10,
+        'pending' => 8,
+        'scheduled' => 1,
+        'reserved' => 1,
+        'oldest_job_age' => 120,
+        'throughput_per_minute' => 5.5,
+        'avg_duration' => 250.0,
+        'failure_rate' => 2.0,
+        'utilization_rate' => 0.75,
+        'active_workers' => 3,
+    ];
+
+    $this->repo->recordSnapshot('redis', 'default', $metrics);
+
+    $latest = $this->repo->getLatestMetrics('redis', 'default');
+
+    expect($latest['depth'])->toBe(10);
+    expect($latest['pending'])->toBe(8);
+    expect($latest['scheduled'])->toBe(1);
+    expect($latest['reserved'])->toBe(1);
+    expect($latest['oldest_job_age'])->toBe(120);
+    expect($latest['throughput_per_minute'])->toBe(5.5);
+    expect($latest['avg_duration'])->toBe(250.0);
+    expect($latest['failure_rate'])->toBe(2.0);
+    expect($latest['utilization_rate'])->toBe(0.75);
+    expect($latest['active_workers'])->toBe(3);
+    expect($latest['recorded_at'])->not->toBeNull();
+});
+
+test('getLatestMetrics returns empty array when no snapshot exists', function () {
+    $latest = $this->repo->getLatestMetrics('redis', 'default');
+    expect($latest)->toBe([]);
+});
+
+test('recordSnapshot trims sorted set to 1000 entries', function () {
+    // Record 1005 snapshots
+    for ($i = 0; $i < 1005; $i++) {
+        $this->repo->recordSnapshot('redis', 'default', [
+            'depth' => $i,
+            'pending' => $i,
+        ]);
+    }
+
+    // Check sorted set count - should be trimmed to 1000
+    $timestampKey = $this->store->key('queue_snapshots', 'redis', 'default');
+    $count = $this->store->countSortedSetByScore($timestampKey, '-inf', '+inf');
+
+    expect($count)->toBeLessThanOrEqual(1000);
+});
+
+// --- getHealthStatus ---
+
+test('getHealthStatus returns unknown when no metrics exist', function () {
+    Event::fake();
+
+    $status = $this->repo->getHealthStatus('redis', 'default');
+
+    expect($status['status'])->toBe('unknown');
+    expect($status['score'])->toBe(0.0);
+});
+
+test('getHealthStatus returns healthy for good metrics', function () {
+    Event::fake();
+
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 10,
+        'pending' => 10,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 60,
+        'throughput_per_minute' => 10.0,
+        'avg_duration' => 100.0,
+        'failure_rate' => 0.0,
+        'utilization_rate' => 0.5,
+        'active_workers' => 5,
+    ]);
+
+    $status = $this->repo->getHealthStatus('redis', 'default');
+
+    expect($status['status'])->toBe('healthy');
+    expect($status['score'])->toBe(100.0);
+});
+
+test('getHealthStatus returns warning for moderate issues', function () {
+    Event::fake();
+
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 250,
+        'pending' => 250,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 400,
+        'throughput_per_minute' => 2.0,
+        'avg_duration' => 500.0,
+        'failure_rate' => 5.0,
+        'utilization_rate' => 0.9,
+        'active_workers' => 2,
+    ]);
+
+    $status = $this->repo->getHealthStatus('redis', 'default');
+
+    expect($status['status'])->toBe('warning');
+    expect($status['score'])->toBeGreaterThanOrEqual(50.0);
+    expect($status['score'])->toBeLessThan(80.0);
+});
+
+test('getHealthStatus returns critical for severe issues', function () {
+    Event::fake();
+
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 500,
+        'pending' => 500,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 3000,
+        'throughput_per_minute' => 0.0,
+        'avg_duration' => 1000.0,
+        'failure_rate' => 20.0,
+        'utilization_rate' => 1.0,
+        'active_workers' => 0,
+    ]);
+
+    $status = $this->repo->getHealthStatus('redis', 'default');
+
+    expect($status['status'])->toBe('critical');
+    expect($status['score'])->toBeLessThan(50.0);
+});
+
+test('getHealthStatus dispatches HealthScoreChanged event on significant change', function () {
+    Event::fake();
+
+    // Record healthy metrics and get health status to establish baseline
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 10,
+        'pending' => 10,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 0,
+        'throughput_per_minute' => 10.0,
+        'avg_duration' => 100.0,
+        'failure_rate' => 0.0,
+        'utilization_rate' => 0.5,
+        'active_workers' => 5,
+    ]);
+    $this->repo->getHealthStatus('redis', 'default'); // Score = 100
+
+    // Now record bad metrics
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 500,
+        'pending' => 500,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 3000,
+        'throughput_per_minute' => 0.0,
+        'avg_duration' => 1000.0,
+        'failure_rate' => 20.0,
+        'utilization_rate' => 1.0,
+        'active_workers' => 0,
+    ]);
+    $this->repo->getHealthStatus('redis', 'default'); // Score should be much lower
+
+    Event::assertDispatched(HealthScoreChanged::class, function (HealthScoreChanged $event) {
+        return $event->connection === 'redis'
+            && $event->queue === 'default'
+            && $event->previousScore === 100.0;
+    });
+});
+
+test('getHealthStatus does not dispatch event on small change', function () {
+    Event::fake();
+
+    // Record healthy metrics to establish baseline
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 10,
+        'pending' => 10,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 0,
+        'throughput_per_minute' => 10.0,
+        'avg_duration' => 100.0,
+        'failure_rate' => 0.0,
+        'utilization_rate' => 0.5,
+        'active_workers' => 5,
+    ]);
+    $this->repo->getHealthStatus('redis', 'default'); // Score = 100
+
+    // Record metrics with only a tiny change (depth 110 = small penalty)
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 110,
+        'pending' => 110,
+        'scheduled' => 0,
+        'reserved' => 0,
+        'oldest_job_age' => 0,
+        'throughput_per_minute' => 10.0,
+        'avg_duration' => 100.0,
+        'failure_rate' => 0.0,
+        'utilization_rate' => 0.5,
+        'active_workers' => 5,
+    ]);
+    $this->repo->getHealthStatus('redis', 'default'); // Score = 99 (small change)
+
+    Event::assertNotDispatched(HealthScoreChanged::class);
+});
+
+// --- listQueues and markQueueDiscovered ---
+
+test('listQueues returns empty array initially', function () {
+    expect($this->repo->listQueues())->toBe([]);
+});
+
+test('markQueueDiscovered registers queue and listQueues returns it', function () {
+    $this->repo->markQueueDiscovered('redis', 'default');
+    $this->repo->markQueueDiscovered('sqs', 'emails');
+
+    $queues = $this->repo->listQueues();
+    expect($queues)->toHaveCount(2);
+
+    $connections = array_column($queues, 'connection');
+    $queueNames = array_column($queues, 'queue');
+    expect($connections)->toContain('redis');
+    expect($connections)->toContain('sqs');
+    expect($queueNames)->toContain('default');
+    expect($queueNames)->toContain('emails');
+});
+
+test('markQueueDiscovered does not create duplicates', function () {
+    $this->repo->markQueueDiscovered('redis', 'default');
+    $this->repo->markQueueDiscovered('redis', 'default');
+
+    $queues = $this->repo->listQueues();
+    expect($queues)->toHaveCount(1);
+});
+
+// --- cleanup ---
+
+test('cleanup removes old snapshots', function () {
+    // Create an old snapshot
+    $oldKey = $this->store->key('queue_snapshot', 'redis', 'default');
+    $this->store->setHash($oldKey, [
+        'depth' => 5,
+        'recorded_at' => now()->subDays(10)->timestamp,
+    ]);
+
+    // Create a recent snapshot
+    $recentKey = $this->store->key('queue_snapshot', 'sqs', 'emails');
+    $this->store->setHash($recentKey, [
+        'depth' => 3,
+        'recorded_at' => now()->timestamp,
+    ]);
+
+    $deleted = $this->repo->cleanup(86400); // Older than 1 day
+
+    expect($deleted)->toBe(1);
+    expect($this->store->getHash($oldKey))->toBe([]);
+    expect($this->store->getHash($recentKey))->not->toBe([]);
+});
+
+test('cleanup returns zero when nothing to clean', function () {
+    $key = $this->store->key('queue_snapshot', 'redis', 'default');
+    $this->store->setHash($key, [
+        'depth' => 3,
+        'recorded_at' => now()->timestamp,
+    ]);
+
+    $deleted = $this->repo->cleanup(86400);
+    expect($deleted)->toBe(0);
+});
+
+test('cleanup skips keys without recorded_at', function () {
+    $key = $this->store->key('queue_snapshot', 'redis', 'default');
+    $this->store->setHash($key, ['depth' => 1]);
+
+    $deleted = $this->repo->cleanup(86400);
+    expect($deleted)->toBe(0);
+});

--- a/tests/Feature/Repositories/DatabaseWorkerHeartbeatRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseWorkerHeartbeatRepositoryTest.php
@@ -1,0 +1,687 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+    $this->repo = new DatabaseWorkerHeartbeatRepository($this->store);
+});
+
+// --- recordHeartbeat ---
+
+test('recordHeartbeat creates new worker entry', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 123,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+
+    expect($worker)->not->toBeNull();
+    expect($worker->workerId)->toBe('worker-1');
+    expect($worker->connection)->toBe('redis');
+    expect($worker->queue)->toBe('default');
+    expect($worker->state)->toBe(WorkerState::IDLE);
+    expect($worker->pid)->toBe(123);
+    expect($worker->hostname)->toBe('prod-01');
+    expect($worker->jobsProcessed)->toBe(0);
+});
+
+test('recordHeartbeat updates worker with state transitions', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 123,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker)->not->toBeNull();
+    expect($worker->state)->toBe(WorkerState::IDLE);
+
+    // Transition to BUSY
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-42',
+        currentJobClass: 'App\\Jobs\\SendEmail',
+        pid: 123,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->state)->toBe(WorkerState::BUSY);
+    expect($worker->currentJobClass)->toBe('App\\Jobs\\SendEmail');
+});
+
+test('recordHeartbeat increments jobs_processed on busy to idle transition', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
+    // Start as BUSY with a job
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\ProcessOrder',
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:05'));
+
+    // Transition to IDLE with no job (job completed)
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->jobsProcessed)->toBe(1);
+
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:06'));
+
+    // Go busy again
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-2',
+        currentJobClass: 'App\\Jobs\\SendEmail',
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:10'));
+
+    // Complete second job
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->jobsProcessed)->toBe(2);
+
+    Carbon::setTestNow();
+});
+
+test('recordHeartbeat tracks peak memory usage', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+        memoryUsageMb: 50.0,
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->peakMemoryUsageMb)->toBe(50.0);
+
+    // Higher memory
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+        memoryUsageMb: 120.0,
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->peakMemoryUsageMb)->toBe(120.0);
+
+    // Lower memory - peak should not decrease
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+        memoryUsageMb: 30.0,
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->peakMemoryUsageMb)->toBe(120.0);
+    expect($worker->memoryUsageMb)->toBe(30.0);
+});
+
+test('recordHeartbeat accumulates idle and busy time', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    // 10 seconds pass while idle
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:10'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\Test',
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->idleTimeSeconds)->toBe(10.0);
+    expect($worker->busyTimeSeconds)->toBe(0.0);
+
+    // 5 seconds pass while busy
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:15'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->idleTimeSeconds)->toBe(10.0);
+    expect($worker->busyTimeSeconds)->toBe(5.0);
+
+    Carbon::setTestNow();
+});
+
+// --- transitionState ---
+
+test('transitionState changes worker state', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    $this->repo->transitionState('worker-1', WorkerState::PAUSED, Carbon::now());
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->state)->toBe(WorkerState::PAUSED);
+});
+
+test('transitionState does nothing for non-existent worker', function () {
+    // Should not throw
+    $this->repo->transitionState('non-existent', WorkerState::CRASHED, Carbon::now());
+
+    expect($this->repo->getWorker('non-existent'))->toBeNull();
+});
+
+// --- getWorker ---
+
+test('getWorker returns null for non-existent worker', function () {
+    expect($this->repo->getWorker('non-existent'))->toBeNull();
+});
+
+test('getWorker returns WorkerHeartbeat for existing worker', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 200,
+        hostname: 'web-01',
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+
+    expect($worker)->not->toBeNull();
+    expect($worker->workerId)->toBe('worker-1');
+    expect($worker->connection)->toBe('redis');
+    expect($worker->queue)->toBe('default');
+    expect($worker->pid)->toBe(200);
+    expect($worker->hostname)->toBe('web-01');
+});
+
+// --- getActiveWorkers ---
+
+test('getActiveWorkers returns only active workers', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-idle',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-busy',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\Test',
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-paused',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::PAUSED,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 3,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-stopped',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::STOPPED,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 4,
+        hostname: 'host',
+    );
+
+    $active = $this->repo->getActiveWorkers();
+    expect($active)->toHaveCount(2);
+
+    $ids = $active->pluck('workerId')->all();
+    expect($ids)->toContain('worker-idle');
+    expect($ids)->toContain('worker-busy');
+});
+
+test('getActiveWorkers filters by connection', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-redis',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-sqs',
+        connection: 'sqs',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $workers = $this->repo->getActiveWorkers(connection: 'redis');
+    expect($workers)->toHaveCount(1);
+    expect($workers->first()->workerId)->toBe('worker-redis');
+});
+
+test('getActiveWorkers filters by queue', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-default',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-emails',
+        connection: 'redis',
+        queue: 'emails',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $workers = $this->repo->getActiveWorkers(queue: 'emails');
+    expect($workers)->toHaveCount(1);
+    expect($workers->first()->workerId)->toBe('worker-emails');
+});
+
+test('getActiveWorkers filters by both connection and queue', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-2',
+        connection: 'redis',
+        queue: 'emails',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-3',
+        connection: 'sqs',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 3,
+        hostname: 'host',
+    );
+
+    $workers = $this->repo->getActiveWorkers(connection: 'redis', queue: 'default');
+    expect($workers)->toHaveCount(1);
+    expect($workers->first()->workerId)->toBe('worker-1');
+});
+
+// --- getWorkersByState ---
+
+test('getWorkersByState returns workers matching state', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-idle-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-idle-2',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-busy',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\Test',
+        pid: 3,
+        hostname: 'host',
+    );
+
+    $idleWorkers = $this->repo->getWorkersByState(WorkerState::IDLE);
+    expect($idleWorkers)->toHaveCount(2);
+
+    $busyWorkers = $this->repo->getWorkersByState(WorkerState::BUSY);
+    expect($busyWorkers)->toHaveCount(1);
+    expect($busyWorkers->first()->workerId)->toBe('worker-busy');
+
+    $pausedWorkers = $this->repo->getWorkersByState(WorkerState::PAUSED);
+    expect($pausedWorkers)->toHaveCount(0);
+});
+
+// --- detectStaledWorkers ---
+
+test('detectStaledWorkers marks active stale workers as crashed', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
+    // Register two active workers
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-stale',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-fresh',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\Test',
+        pid: 2,
+        hostname: 'host',
+    );
+
+    // Move time forward so worker-stale becomes stale
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:02:00'));
+
+    // Update worker-fresh so it stays current
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-fresh',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::BUSY,
+        currentJobId: 'job-1',
+        currentJobClass: 'App\\Jobs\\Test',
+        pid: 2,
+        hostname: 'host',
+    );
+
+    $markedCount = $this->repo->detectStaledWorkers(thresholdSeconds: 60);
+
+    expect($markedCount)->toBe(1);
+
+    $staleWorker = $this->repo->getWorker('worker-stale');
+    expect($staleWorker->state)->toBe(WorkerState::CRASHED);
+
+    $freshWorker = $this->repo->getWorker('worker-fresh');
+    expect($freshWorker->state)->toBe(WorkerState::BUSY);
+
+    Carbon::setTestNow();
+});
+
+test('detectStaledWorkers does not mark non-active workers as crashed', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-stopped',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::STOPPED,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:02:00'));
+
+    $markedCount = $this->repo->detectStaledWorkers(thresholdSeconds: 60);
+
+    expect($markedCount)->toBe(0);
+
+    $worker = $this->repo->getWorker('worker-stopped');
+    expect($worker->state)->toBe(WorkerState::STOPPED);
+
+    Carbon::setTestNow();
+});
+
+// --- removeWorker ---
+
+test('removeWorker deletes worker hash and sorted set entry', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+    );
+
+    expect($this->repo->getWorker('worker-1'))->not->toBeNull();
+
+    $this->repo->removeWorker('worker-1');
+
+    expect($this->repo->getWorker('worker-1'))->toBeNull();
+
+    // Verify also removed from sorted set (getActiveWorkers should be empty)
+    $active = $this->repo->getActiveWorkers();
+    expect($active)->toHaveCount(0);
+});
+
+test('removeWorker is safe for non-existent worker', function () {
+    // Should not throw
+    $this->repo->removeWorker('non-existent');
+
+    expect($this->repo->getActiveWorkers())->toHaveCount(0);
+});
+
+// --- cleanup ---
+
+test('cleanup removes old worker records', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-old',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    Carbon::setTestNow(Carbon::parse('2025-01-01 14:00:00'));
+
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-recent',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 2,
+        hostname: 'host',
+    );
+
+    // Cleanup workers older than 1 hour
+    $cleaned = $this->repo->cleanup(olderThanSeconds: 3600);
+
+    expect($cleaned)->toBe(1);
+    expect($this->repo->getWorker('worker-old'))->toBeNull();
+    expect($this->repo->getWorker('worker-recent'))->not->toBeNull();
+
+    Carbon::setTestNow();
+});
+
+test('cleanup returns zero when no old workers exist', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 1,
+        hostname: 'host',
+    );
+
+    $cleaned = $this->repo->cleanup(olderThanSeconds: 3600);
+
+    expect($cleaned)->toBe(0);
+});
+
+test('recordHeartbeat stores cpu usage', function () {
+    $this->repo->recordHeartbeat(
+        workerId: 'worker-1',
+        connection: 'redis',
+        queue: 'default',
+        state: WorkerState::IDLE,
+        currentJobId: null,
+        currentJobClass: null,
+        pid: 100,
+        hostname: 'prod-01',
+        memoryUsageMb: 64.5,
+        cpuUsagePercent: 23.7,
+    );
+
+    $worker = $this->repo->getWorker('worker-1');
+    expect($worker->memoryUsageMb)->toBe(64.5);
+    expect($worker->cpuUsagePercent)->toBe(23.7);
+});

--- a/tests/Feature/Repositories/DatabaseWorkerHeartbeatRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseWorkerHeartbeatRepositoryTest.php
@@ -6,12 +6,15 @@ use Carbon\Carbon;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
 use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerHeartbeatRepository;
 use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+use Cbox\LaravelQueueMetrics\Support\HeartbeatThrottleCache;
 
 beforeEach(function () {
     config()->set('queue-metrics.storage.connection', null);
 
     $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
     $migration->up();
+
+    HeartbeatThrottleCache::reset();
 
     $this->store = new DatabaseMetricsStore;
     $this->repo = new DatabaseWorkerHeartbeatRepository($this->store);
@@ -143,6 +146,8 @@ test('recordHeartbeat increments jobs_processed on busy to idle transition', fun
 });
 
 test('recordHeartbeat tracks peak memory usage', function () {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:00'));
+
     $this->repo->recordHeartbeat(
         workerId: 'worker-1',
         connection: 'redis',
@@ -157,6 +162,9 @@ test('recordHeartbeat tracks peak memory usage', function () {
 
     $worker = $this->repo->getWorker('worker-1');
     expect($worker->peakMemoryUsageMb)->toBe(50.0);
+
+    // Advance time to exceed heartbeat throttle window
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:11'));
 
     // Higher memory
     $this->repo->recordHeartbeat(
@@ -174,6 +182,9 @@ test('recordHeartbeat tracks peak memory usage', function () {
     $worker = $this->repo->getWorker('worker-1');
     expect($worker->peakMemoryUsageMb)->toBe(120.0);
 
+    // Advance time again
+    Carbon::setTestNow(Carbon::parse('2025-01-01 12:00:22'));
+
     // Lower memory - peak should not decrease
     $this->repo->recordHeartbeat(
         workerId: 'worker-1',
@@ -190,6 +201,8 @@ test('recordHeartbeat tracks peak memory usage', function () {
     $worker = $this->repo->getWorker('worker-1');
     expect($worker->peakMemoryUsageMb)->toBe(120.0);
     expect($worker->memoryUsageMb)->toBe(30.0);
+
+    Carbon::setTestNow();
 });
 
 test('recordHeartbeat accumulates idle and busy time', function () {

--- a/tests/Feature/Repositories/DatabaseWorkerRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseWorkerRepositoryTest.php
@@ -46,6 +46,7 @@ test('update worker activity changes status and metadata', function () {
     expect($stats)->not->toBeNull();
     expect($stats->status)->toBe('busy');
     expect($stats->currentJob)->toBe('App\\Jobs\\SendEmail');
+    expect($stats->jobsProcessed)->toBe(5);
     expect($stats->idlePercentage)->toBe(25.0);
 });
 

--- a/tests/Feature/Repositories/DatabaseWorkerRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseWorkerRepositoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Repositories\DatabaseWorkerRepository;
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+beforeEach(function () {
+    config()->set('queue-metrics.storage.connection', null);
+
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+    $this->repo = new DatabaseWorkerRepository($this->store);
+});
+
+test('register and retrieve worker', function () {
+    $this->repo->registerWorker(123, 'prod-01', 'redis', 'default', now());
+
+    $stats = $this->repo->getWorkerStats(123, 'prod-01');
+
+    expect($stats)->not->toBeNull();
+    expect($stats->pid)->toBe(123);
+    expect($stats->hostname)->toBe('prod-01');
+    expect($stats->connection)->toBe('redis');
+    expect($stats->queue)->toBe('default');
+    expect($stats->status)->toBe('idle');
+    expect($stats->jobsProcessed)->toBe(0);
+});
+
+test('unregister removes worker', function () {
+    $this->repo->registerWorker(123, 'prod-01', 'redis', 'default', now());
+
+    $this->repo->unregisterWorker(123, 'prod-01');
+
+    expect($this->repo->getWorkerStats(123, 'prod-01'))->toBeNull();
+});
+
+test('update worker activity changes status and metadata', function () {
+    $this->repo->registerWorker(123, 'prod-01', 'redis', 'default', now());
+
+    $this->repo->updateWorkerActivity(123, 'prod-01', 'busy', 'App\\Jobs\\SendEmail', 5, 25.0);
+
+    $stats = $this->repo->getWorkerStats(123, 'prod-01');
+    expect($stats)->not->toBeNull();
+    expect($stats->status)->toBe('busy');
+    expect($stats->currentJob)->toBe('App\\Jobs\\SendEmail');
+    expect($stats->idlePercentage)->toBe(25.0);
+});
+
+test('getActiveWorkers returns all workers when no filters', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now());
+    $this->repo->registerWorker(2, 'host', 'redis', 'emails', now());
+
+    $workers = $this->repo->getActiveWorkers();
+
+    expect($workers)->toHaveCount(2);
+});
+
+test('getActiveWorkers filters by connection and queue', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now());
+    $this->repo->registerWorker(2, 'host', 'redis', 'emails', now());
+    $this->repo->registerWorker(3, 'host', 'sqs', 'default', now());
+
+    $workers = $this->repo->getActiveWorkers('redis', 'default');
+
+    expect($workers)->toHaveCount(1);
+    expect($workers[0]->pid)->toBe(1);
+});
+
+test('getActiveWorkers filters by connection only', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now());
+    $this->repo->registerWorker(2, 'host', 'redis', 'emails', now());
+    $this->repo->registerWorker(3, 'host', 'sqs', 'default', now());
+
+    $workers = $this->repo->getActiveWorkers('redis');
+
+    expect($workers)->toHaveCount(2);
+});
+
+test('countActiveWorkers returns count', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now());
+    $this->repo->registerWorker(2, 'host', 'redis', 'default', now());
+
+    expect($this->repo->countActiveWorkers('redis', 'default'))->toBe(2);
+});
+
+test('cleanupStaleWorkers removes old workers', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now()->subMinutes(5));
+    $this->repo->registerWorker(2, 'host', 'redis', 'default', now());
+
+    $removed = $this->repo->cleanupStaleWorkers(60);
+
+    expect($removed)->toBe(1);
+    expect($this->repo->getWorkerStats(1, 'host'))->toBeNull();
+    expect($this->repo->getWorkerStats(2, 'host'))->not->toBeNull();
+});
+
+test('cleanupStaleWorkers returns zero when no stale workers', function () {
+    $this->repo->registerWorker(1, 'host', 'redis', 'default', now());
+
+    $removed = $this->repo->cleanupStaleWorkers(60);
+
+    expect($removed)->toBe(0);
+});
+
+test('getWorkerStats returns null for non-existent worker', function () {
+    expect($this->repo->getWorkerStats(999, 'unknown-host'))->toBeNull();
+});

--- a/tests/Feature/Support/DatabaseMetricsStoreTest.php
+++ b/tests/Feature/Support/DatabaseMetricsStoreTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
+
+beforeEach(function () {
+    // Models read queue-metrics.storage.connection for DB connection name.
+    // Set to null so models fall back to Laravel's default connection ('testing').
+    config()->set('queue-metrics.storage.connection', null);
+
+    // Run the package migration (not auto-loaded since runsMigrations is not called).
+    $migration = include __DIR__.'/../../../database/migrations/2024_01_01_000001_create_queue_metrics_storage_tables.php';
+    $migration->up();
+
+    $this->store = new DatabaseMetricsStore;
+});
+
+// --- String operations ---
+
+test('set and get a string value', function () {
+    $this->store->set('test:key', 'hello');
+    expect($this->store->get('test:key'))->toBe('hello');
+});
+
+test('set with TTL expires key', function () {
+    $this->store->set('test:ttl', 'value', 1);
+    expect($this->store->get('test:ttl'))->toBe('value');
+
+    $this->travel(2)->seconds();
+    expect($this->store->get('test:ttl'))->toBeNull();
+});
+
+test('exists returns true for existing key', function () {
+    $this->store->set('test:exists', 'yes');
+    expect($this->store->exists('test:exists'))->toBeTrue();
+    expect($this->store->exists('test:nope'))->toBeFalse();
+});
+
+test('delete removes key', function () {
+    $this->store->set('test:del', 'value');
+    $this->store->delete('test:del');
+    expect($this->store->get('test:del'))->toBeNull();
+});
+
+// --- Hash operations ---
+
+test('setHash and getHash', function () {
+    $this->store->setHash('test:hash', ['name' => 'Alice', 'age' => '30']);
+    expect($this->store->getHash('test:hash'))->toBe(['name' => 'Alice', 'age' => '30']);
+});
+
+test('getHashField returns single field', function () {
+    $this->store->setHash('test:hash', ['a' => '1', 'b' => '2']);
+    expect($this->store->getHashField('test:hash', 'a'))->toBe('1');
+});
+
+test('incrementHashField increments integer', function () {
+    $this->store->setHash('test:inc', ['count' => '5']);
+    $this->store->incrementHashField('test:inc', 'count', 3);
+    expect($this->store->getHashField('test:inc', 'count'))->toBe(8);
+});
+
+test('incrementHashField increments float', function () {
+    $this->store->setHash('test:incf', ['total' => '1.5']);
+    $this->store->incrementHashField('test:incf', 'total', 2.5);
+    // JSON serialization may convert 4.0 to int 4, so check numeric equality.
+    expect($this->store->getHashField('test:incf', 'total'))->toEqual(4.0);
+});
+
+test('incrementHashField creates field if missing', function () {
+    $this->store->setHash('test:inc-new', ['other' => 'x']);
+    $this->store->incrementHashField('test:inc-new', 'count', 1);
+    expect($this->store->getHashField('test:inc-new', 'count'))->toBe(1);
+});
+
+// --- Sorted set operations ---
+
+test('addToSortedSet and getSortedSetByScore', function () {
+    $this->store->addToSortedSet('test:zset', ['alice' => 10, 'bob' => 20, 'carol' => 15]);
+    $result = $this->store->getSortedSetByScore('test:zset', '0', '100');
+    expect($result)->toBe(['alice', 'carol', 'bob']);
+});
+
+test('getSortedSetByRank returns by position', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 1, 'b' => 2, 'c' => 3]);
+    expect($this->store->getSortedSetByRank('test:zset', 0, 1))->toBe(['a', 'b']);
+});
+
+test('getSortedSetByRank with negative indices', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+    expect($this->store->getSortedSetByRank('test:zset', 0, -1))->toBe(['a', 'b', 'c', 'd']);
+    expect($this->store->getSortedSetByRank('test:zset', -2, -1))->toBe(['c', 'd']);
+});
+
+test('countSortedSetByScore counts within range', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 10, 'b' => 20, 'c' => 30]);
+    expect($this->store->countSortedSetByScore('test:zset', '15', '25'))->toBe(1);
+});
+
+test('removeSortedSetByScore removes matching entries', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 10, 'b' => 20, 'c' => 30]);
+    $this->store->removeSortedSetByScore('test:zset', '0', '15');
+    expect($this->store->getSortedSetByScore('test:zset', '0', '100'))->toBe(['b', 'c']);
+});
+
+test('removeSortedSetByRank removes by position', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+    $this->store->removeSortedSetByRank('test:zset', 0, 1);
+    expect($this->store->getSortedSetByScore('test:zset', '0', '100'))->toBe(['c', 'd']);
+});
+
+test('removeFromSortedSet removes specific member', function () {
+    $this->store->addToSortedSet('test:zset', ['a' => 1, 'b' => 2]);
+    $this->store->removeFromSortedSet('test:zset', 'a');
+    expect($this->store->getSortedSetByScore('test:zset', '0', '100'))->toBe(['b']);
+});
+
+// --- Set operations ---
+
+test('addToSet and getSetMembers', function () {
+    $this->store->addToSet('test:set', ['x', 'y', 'z']);
+    $members = $this->store->getSetMembers('test:set');
+    sort($members);
+    expect($members)->toBe(['x', 'y', 'z']);
+});
+
+test('addToSet ignores duplicates', function () {
+    $this->store->addToSet('test:set', ['x', 'y']);
+    $this->store->addToSet('test:set', ['y', 'z']);
+    expect($this->store->getSetMembers('test:set'))->toHaveCount(3);
+});
+
+test('removeFromSet removes members', function () {
+    $this->store->addToSet('test:set', ['a', 'b', 'c']);
+    $this->store->removeFromSet('test:set', ['b']);
+    $members = $this->store->getSetMembers('test:set');
+    sort($members);
+    expect($members)->toBe(['a', 'c']);
+});
+
+// --- Key scanning ---
+
+test('scanKeys finds matching keys', function () {
+    $this->store->set('prefix:a', '1');
+    $this->store->set('prefix:b', '2');
+    $this->store->set('other:c', '3');
+    $keys = $this->store->scanKeys('prefix:*');
+    sort($keys);
+    expect($keys)->toBe(['prefix:a', 'prefix:b']);
+});
+
+// --- Transaction ---
+
+test('transaction wraps operations atomically', function () {
+    $this->store->transaction(function () {
+        $this->store->set('tx:a', '1');
+        $this->store->set('tx:b', '2');
+    });
+    expect($this->store->get('tx:a'))->toBe('1');
+    expect($this->store->get('tx:b'))->toBe('2');
+});

--- a/tests/Unit/Config/StorageConfigTest.php
+++ b/tests/Unit/Config/StorageConfigTest.php
@@ -23,7 +23,9 @@ it('creates config from array with all values', function () {
             'raw' => 1800,
             'aggregated' => 86400,
             'baseline' => 604800,
-        ]);
+        ])
+        ->and($config->maxSamplesPerKey)->toBe(1000)
+        ->and($config->cleanupChunkSize)->toBe(1000);
 })->group('functional');
 
 it('creates config with defaults when values missing', function () {
@@ -36,7 +38,9 @@ it('creates config with defaults when values missing', function () {
             'raw' => 3600,
             'aggregated' => 604800,
             'baseline' => 2592000,
-        ]);
+        ])
+        ->and($config->maxSamplesPerKey)->toBe(1000)
+        ->and($config->cleanupChunkSize)->toBe(1000);
 })->group('functional');
 
 it('gets ttl for known type', function () {
@@ -71,6 +75,16 @@ it('handles database driver', function () {
 
     expect($config->driver)->toBe('database')
         ->and($config->connection)->toBe('mysql');
+})->group('functional');
+
+it('creates config with custom max_samples_per_key and cleanup_chunk_size', function () {
+    $config = StorageConfig::fromArray([
+        'max_samples_per_key' => 500,
+        'cleanup_chunk_size' => 2000,
+    ]);
+
+    expect($config->maxSamplesPerKey)->toBe(500)
+        ->and($config->cleanupChunkSize)->toBe(2000);
 })->group('functional');
 
 it('is readonly', function () {


### PR DESCRIPTION
## Summary

- Adds a complete database storage driver as an alternative to Redis for applications without Redis infrastructure
- Implements `DatabaseMetricsStore` wrapping 4 Eloquent models (`MetricsKey`, `MetricsHash`, `MetricsSet`, `MetricsSortedSet`) that map to existing migration tables
- Adds 5 database repository implementations (`DatabaseWorkerRepository`, `DatabaseWorkerHeartbeatRepository`, `DatabaseJobMetricsRepository`, `DatabaseQueueMetricsRepository`, `DatabaseBaselineRepository`) that mirror Redis behavior using DB transactions instead of Lua scripts
- Adds `queue-metrics:cleanup-database` command for expired data removal and sample trimming
- Wires driver selection via config — setting `QUEUE_METRICS_STORAGE=database` automatically binds all database repositories; explicit repository overrides still take precedence

## Architecture

- `DatabaseMetricsStore` provides the same public API as `RedisMetricsStore` (string, hash, sorted set, set, scan, transaction operations) backed by Eloquent
- Repository config values default to `null`, resolved at boot time based on the configured storage driver
- Lua script logic (heartbeat state transitions, throughput calculations) replaced with `DB::transaction` blocks
- Database cleanup scheduled automatically every minute when using the database driver

## Test Plan

- [ ] 273 tests pass (158 new tests for database driver, 15 Redis-only tests skipped)
- [ ] Verify `QUEUE_METRICS_STORAGE=database` binds database repositories
- [ ] Verify explicit repository overrides take precedence over driver defaults
- [ ] Verify cleanup command removes expired keys, hashes, and sorted set entries
- [ ] Verify sorted set trimming keeps entries within `max_samples_per_key` limit
- [ ] Test with MySQL/PostgreSQL (tests use SQLite in-memory)