### PR TITLE
feat: add persistence.enabled config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `laravel-queue-metrics` will be documented in this file.
 
+## v2.6.0 - Persistence toggle - 2026-04-09
+
+### What's Changed
+
+* feat: Add `persistence.enabled` config option (`QUEUE_METRICS_PERSISTENCE` env) — when `false`, listeners still instrument jobs and fire `JobMetricsCompleted`/`JobMetricsFailed` events but skip all repository writes; scheduled tasks are not registered; no Redis or database connection is required
+* tests: Add 11 tests covering persistence-disabled behavior (events fire, no repository calls, no scheduled tasks)
+* docs: Document `persistence.enabled` in configuration reference and events docs
+
+**Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.5.0...v2.6.0
+
 ## v2.5.0 - Database storage driver - 2026-04-09
 
 ### What's Changed

--- a/config/queue-metrics.php
+++ b/config/queue-metrics.php
@@ -29,6 +29,10 @@ return [
 
     'enabled' => env('QUEUE_METRICS_ENABLED', true),
 
+    'persistence' => [
+        'enabled' => env('QUEUE_METRICS_PERSISTENCE', true),
+    ],
+
     'storage' => [
         'driver' => env('QUEUE_METRICS_STORAGE', 'redis'),
         'connection' => env('QUEUE_METRICS_CONNECTION', 'default'),

--- a/docs/advanced-usage/events.md
+++ b/docs/advanced-usage/events.md
@@ -78,6 +78,7 @@ $event->metrics->lastFailure;       // ?FailureInfoDTO
 **Dispatched**: When a job completes successfully with process-level metrics
 **Frequency**: High (every successful job)
 **Purpose**: Per-job metrics for downstream consumers (e.g., [Queue Monitor](https://github.com/cboxdk/laravel-queue-monitor))
+**Persistence**: Fires even when `persistence.enabled` is `false` — no storage driver required
 
 ```php
 use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
@@ -112,6 +113,7 @@ $event->workerMemoryLimitMb;   // ?float (PHP memory_limit in MB, null if unlimi
 **Dispatched**: When a job fails with process-level metrics
 **Frequency**: Low (only on failures)
 **Purpose**: Per-job failure metrics for downstream consumers (e.g., [Queue Monitor](https://github.com/cboxdk/laravel-queue-monitor))
+**Persistence**: Fires even when `persistence.enabled` is `false` — no storage driver required
 
 ```php
 use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -31,6 +31,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Persistence
+    |--------------------------------------------------------------------------
+    |
+    | When disabled, listeners still instrument jobs and fire
+    | JobMetricsCompleted / JobMetricsFailed events, but skip all
+    | repository writes (Redis/database). Scheduled tasks are not
+    | registered. No storage driver is required.
+    |
+    */
+    'persistence' => [
+        'enabled' => env('QUEUE_METRICS_PERSISTENCE', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Storage Configuration
     |--------------------------------------------------------------------------
     |
@@ -145,6 +160,10 @@ return [
 # Enable/disable metrics collection
 QUEUE_METRICS_ENABLED=true
 
+# Enable/disable persistence (storage writes and scheduled tasks)
+# When false, events still fire but no Redis/database is needed
+QUEUE_METRICS_PERSISTENCE=true
+
 # Storage configuration
 QUEUE_METRICS_STORAGE=redis
 QUEUE_METRICS_CONNECTION=default
@@ -169,6 +188,16 @@ QUEUE_METRICS_BASELINE_DEVIATION_THRESHOLD=2.0
 ```
 
 ## Configuration Examples
+
+### Event-Only Mode (No Storage)
+
+Use this when you only need `JobMetricsCompleted` / `JobMetricsFailed` events (e.g., forwarding to an external monitoring system) without storing metrics locally:
+
+```env
+QUEUE_METRICS_PERSISTENCE=false
+```
+
+No Redis or database connection is required. Listeners still instrument jobs (duration, memory, CPU) and dispatch events. Scheduled tasks (baselines, trends, cleanup) are skipped entirely.
 
 ### Production Redis Setup
 

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -222,6 +222,10 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             return;
         }
 
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         /** @var int $threshold */
         $threshold = config('queue-metrics.worker_heartbeat.stale_threshold', 60);
 

--- a/src/Listeners/JobExceptionOccurredListener.php
+++ b/src/Listeners/JobExceptionOccurredListener.php
@@ -20,6 +20,10 @@ final readonly class JobExceptionOccurredListener
 
     public function handle(JobExceptionOccurred $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         $job = $event->job;
         $payload = $job->payload();
 

--- a/src/Listeners/JobFailedListener.php
+++ b/src/Listeners/JobFailedListener.php
@@ -55,14 +55,16 @@ final readonly class JobFailedListener
         $hostname = gethostname() ?: 'unknown';
         $jobClass = $payload['displayName'] ?? 'UnknownJob';
 
-        $this->recordJobFailure->execute(
-            jobId: $jobId,
-            jobClass: $jobClass,
-            connection: $connection,
-            queue: $queue,
-            exception: $event->exception,
-            hostname: $hostname,
-        );
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $this->recordJobFailure->execute(
+                jobId: $jobId,
+                jobClass: $jobClass,
+                connection: $connection,
+                queue: $queue,
+                exception: $event->exception,
+                hostname: $hostname,
+            );
+        }
 
         // Fire per-job metrics event for downstream consumers (e.g., queue-monitor)
         $exceptionMessage = $event->exception->getMessage().' in '.$event->exception->getFile().':'.$event->exception->getLine();
@@ -81,15 +83,17 @@ final readonly class JobFailedListener
         );
 
         // Record worker heartbeat with IDLE state (job failed, worker ready for next job)
-        $workerId = $this->getWorkerId();
-        $this->recordWorkerHeartbeat->execute(
-            workerId: $workerId,
-            connection: $connection,
-            queue: $queue,
-            state: WorkerState::IDLE,
-            currentJobId: null,
-            currentJobClass: null,
-        );
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $workerId = $this->getWorkerId();
+            $this->recordWorkerHeartbeat->execute(
+                workerId: $workerId,
+                connection: $connection,
+                queue: $queue,
+                state: WorkerState::IDLE,
+                currentJobId: null,
+                currentJobClass: null,
+            );
+        }
     }
 
     private function getWorkerId(): string

--- a/src/Listeners/JobProcessedListener.php
+++ b/src/Listeners/JobProcessedListener.php
@@ -60,16 +60,18 @@ final readonly class JobProcessedListener
 
         $jobClass = $payload['displayName'] ?? 'UnknownJob';
 
-        $this->recordJobCompletion->execute(
-            jobId: $jobId,
-            jobClass: $jobClass,
-            connection: $connection,
-            queue: $queue,
-            durationMs: $durationMs,
-            memoryMb: $memoryMb,
-            cpuTimeMs: $cpuTimeMs,
-            hostname: $hostname,
-        );
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $this->recordJobCompletion->execute(
+                jobId: $jobId,
+                jobClass: $jobClass,
+                connection: $connection,
+                queue: $queue,
+                durationMs: $durationMs,
+                memoryMb: $memoryMb,
+                cpuTimeMs: $cpuTimeMs,
+                hostname: $hostname,
+            );
+        }
 
         // Fire per-job metrics event for downstream consumers (e.g., queue-monitor)
         JobMetricsCompleted::dispatch(
@@ -85,15 +87,17 @@ final readonly class JobProcessedListener
         );
 
         // Record worker heartbeat with IDLE state (job completed)
-        $workerId = $this->getWorkerId();
-        $this->recordWorkerHeartbeat->execute(
-            workerId: $workerId,
-            connection: $connection,
-            queue: $queue,
-            state: WorkerState::IDLE,
-            currentJobId: null,
-            currentJobClass: null,
-        );
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $workerId = $this->getWorkerId();
+            $this->recordWorkerHeartbeat->execute(
+                workerId: $workerId,
+                connection: $connection,
+                queue: $queue,
+                state: WorkerState::IDLE,
+                currentJobId: null,
+                currentJobClass: null,
+            );
+        }
     }
 
     private function getWorkerId(): string

--- a/src/Listeners/JobProcessingListener.php
+++ b/src/Listeners/JobProcessingListener.php
@@ -41,23 +41,25 @@ final readonly class JobProcessingListener
         $connection = $event->connectionName;
         $queue = $job->getQueue();
 
-        $this->recordJobStart->execute(
-            jobId: $jobId,
-            jobClass: $jobClass,
-            connection: $connection,
-            queue: $queue,
-        );
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $this->recordJobStart->execute(
+                jobId: $jobId,
+                jobClass: $jobClass,
+                connection: $connection,
+                queue: $queue,
+            );
 
-        // Record worker heartbeat with BUSY state
-        $workerId = $this->getWorkerId();
-        $this->recordWorkerHeartbeat->execute(
-            workerId: $workerId,
-            connection: $connection,
-            queue: $queue,
-            state: WorkerState::BUSY,
-            currentJobId: $jobId,
-            currentJobClass: $jobClass,
-        );
+            // Record worker heartbeat with BUSY state
+            $workerId = $this->getWorkerId();
+            $this->recordWorkerHeartbeat->execute(
+                workerId: $workerId,
+                connection: $connection,
+                queue: $queue,
+                state: WorkerState::BUSY,
+                currentJobId: $jobId,
+                currentJobClass: $jobClass,
+            );
+        }
     }
 
     private function getWorkerId(): string

--- a/src/Listeners/JobQueuedListener.php
+++ b/src/Listeners/JobQueuedListener.php
@@ -20,6 +20,10 @@ final readonly class JobQueuedListener
 
     public function handle(JobQueued $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         $connection = $event->connectionName;
         $queue = $event->job->queue ?? 'default';
 

--- a/src/Listeners/JobRetryRequestedListener.php
+++ b/src/Listeners/JobRetryRequestedListener.php
@@ -20,6 +20,10 @@ final readonly class JobRetryRequestedListener
 
     public function handle(JobRetryRequested $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         // $event->job is stdClass - contains raw job data from Laravel queue
         $jobStdClass = $event->job;
 

--- a/src/Listeners/JobTimedOutListener.php
+++ b/src/Listeners/JobTimedOutListener.php
@@ -20,6 +20,10 @@ final readonly class JobTimedOutListener
 
     public function handle(JobTimedOut $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         $job = $event->job;
         $payload = $job->payload();
 

--- a/src/Listeners/LoopingListener.php
+++ b/src/Listeners/LoopingListener.php
@@ -22,6 +22,10 @@ final readonly class LoopingListener
 
     public function handle(Looping $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         $workerId = $this->getWorkerId();
         $connection = $event->connectionName;
         $queue = $event->queue; // Property is always set (string type)

--- a/src/Listeners/WorkerStoppingListener.php
+++ b/src/Listeners/WorkerStoppingListener.php
@@ -22,6 +22,10 @@ final readonly class WorkerStoppingListener
 
     public function handle(WorkerStopping $event): void
     {
+        if (! config('queue-metrics.persistence.enabled', true)) {
+            return;
+        }
+
         $workerId = $this->getWorkerId();
 
         // Transition worker to STOPPED state

--- a/tests/Feature/PersistenceDisabledTest.php
+++ b/tests/Feature/PersistenceDisabledTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Actions\RecordJobCompletionAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordJobFailureAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordJobStartAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
+use Cbox\LaravelQueueMetrics\Actions\TransitionWorkerStateAction;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
+use Cbox\LaravelQueueMetrics\Listeners\JobExceptionOccurredListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobFailedListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobProcessedListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobProcessingListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobQueuedListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobRetryRequestedListener;
+use Cbox\LaravelQueueMetrics\Listeners\JobTimedOutListener;
+use Cbox\LaravelQueueMetrics\Listeners\LoopingListener;
+use Cbox\LaravelQueueMetrics\Listeners\WorkerStoppingListener;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobQueued;
+use Illuminate\Queue\Events\JobRetryRequested;
+use Illuminate\Queue\Events\JobTimedOut;
+use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\WorkerStopping;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    config([
+        'queue-metrics.enabled' => true,
+        'queue-metrics.persistence.enabled' => false,
+    ]);
+
+    $this->jobMetricsRepository = Mockery::mock(JobMetricsRepository::class);
+    $this->workerHeartbeatRepository = Mockery::mock(WorkerHeartbeatRepository::class);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Events still fire with persistence disabled
+|--------------------------------------------------------------------------
+*/
+
+it('fires JobMetricsCompleted event when persistence is disabled', function () {
+    Event::fake([JobMetricsCompleted::class]);
+
+    $recordJobCompletion = new RecordJobCompletionAction($this->jobMetricsRepository);
+    $recordWorkerHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+
+    $this->jobMetricsRepository->shouldNotReceive('recordCompletion');
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $listener = new JobProcessedListener($recordJobCompletion, $recordWorkerHeartbeat);
+
+    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job->shouldReceive('getJobId')->andReturn('job-1');
+    $job->shouldReceive('payload')->andReturn([
+        'displayName' => 'App\Jobs\TestJob',
+        'pushedAt' => microtime(true) - 0.1,
+    ]);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    $event = new JobProcessed('redis', $job);
+    $listener->handle($event);
+
+    Event::assertDispatched(JobMetricsCompleted::class, function ($e) {
+        return $e->jobClass === 'App\Jobs\TestJob'
+            && $e->connection === 'redis'
+            && $e->queue === 'default';
+    });
+})->group('functional');
+
+it('fires JobMetricsFailed event when persistence is disabled', function () {
+    Event::fake([JobMetricsFailed::class]);
+
+    $recordJobFailure = new RecordJobFailureAction($this->jobMetricsRepository);
+    $recordWorkerHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+
+    $this->jobMetricsRepository->shouldNotReceive('recordFailure');
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $listener = new JobFailedListener($recordJobFailure, $recordWorkerHeartbeat);
+
+    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job->shouldReceive('getJobId')->andReturn('job-2');
+    $job->shouldReceive('payload')->andReturn([
+        'displayName' => 'App\Jobs\FailingJob',
+        'pushedAt' => microtime(true) - 0.05,
+    ]);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    $exception = new RuntimeException('Test failure');
+    $event = new JobFailed('redis', $job, $exception);
+    $listener->handle($event);
+
+    Event::assertDispatched(JobMetricsFailed::class, function ($e) {
+        return $e->jobClass === 'App\Jobs\FailingJob'
+            && str_contains($e->exceptionMessage, 'Test failure');
+    });
+})->group('functional');
+
+/*
+|--------------------------------------------------------------------------
+| No repository calls with persistence disabled
+|--------------------------------------------------------------------------
+*/
+
+it('skips repository calls in JobProcessingListener when persistence is disabled', function () {
+    $recordJobStart = new RecordJobStartAction($this->jobMetricsRepository);
+    $recordWorkerHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+
+    $this->jobMetricsRepository->shouldNotReceive('recordStart');
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $listener = new JobProcessingListener($recordJobStart, $recordWorkerHeartbeat);
+
+    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job->shouldReceive('getJobId')->andReturn('job-3');
+    $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\TestJob']);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    $event = new JobProcessing('redis', $job);
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in JobQueuedListener when persistence is disabled', function () {
+    $this->jobMetricsRepository->shouldNotReceive('recordQueuedAt');
+
+    $listener = new JobQueuedListener($this->jobMetricsRepository);
+
+    $job = new stdClass;
+    $job->queue = 'default';
+
+    $event = Mockery::mock(JobQueued::class);
+    $event->connectionName = 'redis';
+    $event->job = $job;
+
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in JobRetryRequestedListener when persistence is disabled', function () {
+    $this->jobMetricsRepository->shouldNotReceive('recordRetryRequested');
+
+    $listener = new JobRetryRequestedListener($this->jobMetricsRepository);
+
+    $jobStdClass = new stdClass;
+    $jobStdClass->id = 'job-4';
+    $jobStdClass->connection = 'redis';
+    $jobStdClass->queue = 'default';
+
+    $event = Mockery::mock(JobRetryRequested::class);
+    $event->job = $jobStdClass;
+    $event->shouldReceive('payload')->andReturn([
+        'displayName' => 'App\Jobs\RetryableJob',
+        'attempts' => 2,
+    ]);
+
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in JobTimedOutListener when persistence is disabled', function () {
+    $this->jobMetricsRepository->shouldNotReceive('recordTimeout');
+
+    $listener = new JobTimedOutListener($this->jobMetricsRepository);
+
+    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job->shouldReceive('getJobId')->andReturn('job-5');
+    $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\SlowJob']);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    $event = new JobTimedOut('redis', $job);
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in JobExceptionOccurredListener when persistence is disabled', function () {
+    $this->jobMetricsRepository->shouldNotReceive('recordException');
+
+    $listener = new JobExceptionOccurredListener($this->jobMetricsRepository);
+
+    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job->shouldReceive('getJobId')->andReturn('job-6');
+    $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\BrokenJob']);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    $exception = new RuntimeException('Something broke');
+    $event = new JobExceptionOccurred('redis', $job, $exception);
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in WorkerStoppingListener when persistence is disabled', function () {
+    $transitionWorkerState = new TransitionWorkerStateAction($this->workerHeartbeatRepository);
+    $this->workerHeartbeatRepository->shouldNotReceive('transitionState');
+
+    $listener = new WorkerStoppingListener($transitionWorkerState);
+
+    $event = new WorkerStopping(0);
+    $listener->handle($event);
+})->group('functional');
+
+it('skips repository calls in LoopingListener when persistence is disabled', function () {
+    $recordWorkerHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $listener = new LoopingListener($recordWorkerHeartbeat);
+
+    $event = new Looping('redis', 'default');
+    $listener->handle($event);
+})->group('functional');
+
+/*
+|--------------------------------------------------------------------------
+| Scheduled tasks not registered when persistence disabled
+|--------------------------------------------------------------------------
+*/
+
+it('does not register scheduled tasks when persistence is disabled', function () {
+    config([
+        'queue-metrics.enabled' => true,
+        'queue-metrics.persistence.enabled' => false,
+        'queue-metrics.scheduling.enabled' => true,
+    ]);
+
+    $schedule = app(Schedule::class);
+    $events = $schedule->events();
+
+    $queueMetricsEvents = array_filter($events, function ($event) {
+        return str_contains($event->command ?? '', 'queue-metrics:');
+    });
+
+    expect($queueMetricsEvents)->toBeEmpty();
+})->group('functional');
+
+/*
+|--------------------------------------------------------------------------
+| Persistence enabled (default) still works
+|--------------------------------------------------------------------------
+*/
+
+it('calls repository when persistence is enabled', function () {
+    config(['queue-metrics.persistence.enabled' => true]);
+
+    $this->jobMetricsRepository->shouldReceive('recordQueuedAt')->once();
+
+    $listener = new JobQueuedListener($this->jobMetricsRepository);
+
+    $job = new stdClass;
+    $job->queue = 'default';
+
+    $event = Mockery::mock(JobQueued::class);
+    $event->connectionName = 'redis';
+    $event->job = $job;
+
+    $listener->handle($event);
+})->group('functional');

--- a/tests/Feature/PersistenceDisabledTest.php
+++ b/tests/Feature/PersistenceDisabledTest.php
@@ -21,6 +21,7 @@ use Cbox\LaravelQueueMetrics\Listeners\WorkerStoppingListener;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
@@ -59,7 +60,7 @@ it('fires JobMetricsCompleted event when persistence is disabled', function () {
 
     $listener = new JobProcessedListener($recordJobCompletion, $recordWorkerHeartbeat);
 
-    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job = Mockery::mock(Job::class);
     $job->shouldReceive('getJobId')->andReturn('job-1');
     $job->shouldReceive('payload')->andReturn([
         'displayName' => 'App\Jobs\TestJob',
@@ -88,7 +89,7 @@ it('fires JobMetricsFailed event when persistence is disabled', function () {
 
     $listener = new JobFailedListener($recordJobFailure, $recordWorkerHeartbeat);
 
-    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job = Mockery::mock(Job::class);
     $job->shouldReceive('getJobId')->andReturn('job-2');
     $job->shouldReceive('payload')->andReturn([
         'displayName' => 'App\Jobs\FailingJob',
@@ -121,7 +122,7 @@ it('skips repository calls in JobProcessingListener when persistence is disabled
 
     $listener = new JobProcessingListener($recordJobStart, $recordWorkerHeartbeat);
 
-    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job = Mockery::mock(Job::class);
     $job->shouldReceive('getJobId')->andReturn('job-3');
     $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\TestJob']);
     $job->shouldReceive('getQueue')->andReturn('default');
@@ -170,7 +171,7 @@ it('skips repository calls in JobTimedOutListener when persistence is disabled',
 
     $listener = new JobTimedOutListener($this->jobMetricsRepository);
 
-    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job = Mockery::mock(Job::class);
     $job->shouldReceive('getJobId')->andReturn('job-5');
     $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\SlowJob']);
     $job->shouldReceive('getQueue')->andReturn('default');
@@ -184,7 +185,7 @@ it('skips repository calls in JobExceptionOccurredListener when persistence is d
 
     $listener = new JobExceptionOccurredListener($this->jobMetricsRepository);
 
-    $job = Mockery::mock(\Illuminate\Contracts\Queue\Job::class);
+    $job = Mockery::mock(Job::class);
     $job->shouldReceive('getJobId')->andReturn('job-6');
     $job->shouldReceive('payload')->andReturn(['displayName' => 'App\Jobs\BrokenJob']);
     $job->shouldReceive('getQueue')->andReturn('default');


### PR DESCRIPTION
## Summary

- Add `persistence.enabled` config option (`QUEUE_METRICS_PERSISTENCE` env, default `true`)
- When `false`: listeners still instrument jobs and fire `JobMetricsCompleted`/`JobMetricsFailed` events, but all repository writes are skipped, scheduled tasks are not registered, and no Redis or database connection is required
- When `true`: no change in behavior

## Changes

**Config**: New `persistence.enabled` option in `config/queue-metrics.php`

**Service provider**: `registerScheduledTasks()` early-returns when persistence is disabled

**6 persistence-only listeners** (JobQueued, JobRetryRequested, JobTimedOut, JobExceptionOccurred, WorkerStopping, Looping): Early return guard in `handle()`

**3 mixed listeners** (JobProcessing, JobProcessed, JobFailed): Action calls wrapped in persistence guard; instrumentation and event dispatch unchanged

**Docs**: Configuration reference, events docs, and changelog updated

**Tests**: 11 new tests covering events fire, no repository calls, no scheduled tasks, and enabled-mode still works

## Test plan

- [x] All 284 tests pass (15 skipped are pre-existing Redis-dependent)
- [x] Pint formatting clean
- [ ] Verify `QUEUE_METRICS_PERSISTENCE=false` works in a real app without Redis configured