### PR TITLE
feat: track debounced jobs as separate metrics (Laravel 13.6+)

### DIFF
--- a/src/Actions/RecordJobDebouncedAction.php
+++ b/src/Actions/RecordJobDebouncedAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Actions;
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+
+/**
+ * Record when a debounced job is discarded (superseded by a newer dispatch).
+ */
+final readonly class RecordJobDebouncedAction
+{
+    public function __construct(
+        private JobMetricsRepository $repository,
+    ) {}
+
+    public function execute(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+    ): void {
+        if (! config('queue-metrics.enabled', true)) {
+            return;
+        }
+
+        $this->repository->recordDebounced(
+            jobId: $jobId,
+            jobClass: $jobClass,
+            connection: $connection,
+            queue: $queue,
+            debouncedAt: Carbon::now(),
+        );
+    }
+}

--- a/src/DataTransferObjects/JobExecutionData.php
+++ b/src/DataTransferObjects/JobExecutionData.php
@@ -14,6 +14,7 @@ final readonly class JobExecutionData
         public int $totalFailed,
         public float $successRate,
         public float $failureRate,
+        public int $totalDebounced = 0,
     ) {}
 
     /**
@@ -24,8 +25,11 @@ final readonly class JobExecutionData
         $totalProcessedValue = $data['total_processed'] ?? 0;
         $totalFailedValue = $data['total_failed'] ?? 0;
 
+        $totalDebouncedValue = $data['total_debounced'] ?? 0;
+
         $totalProcessed = is_numeric($totalProcessedValue) ? (int) $totalProcessedValue : 0;
         $totalFailed = is_numeric($totalFailedValue) ? (int) $totalFailedValue : 0;
+        $totalDebounced = is_numeric($totalDebouncedValue) ? (int) $totalDebouncedValue : 0;
         $total = $totalProcessed + $totalFailed;
 
         return new self(
@@ -33,6 +37,7 @@ final readonly class JobExecutionData
             totalFailed: $totalFailed,
             successRate: $total > 0 ? ($totalProcessed / $total) * 100 : 0.0,
             failureRate: $total > 0 ? ($totalFailed / $total) * 100 : 0.0,
+            totalDebounced: $totalDebounced,
         );
     }
 
@@ -44,6 +49,7 @@ final readonly class JobExecutionData
         return [
             'total_processed' => $this->totalProcessed,
             'total_failed' => $this->totalFailed,
+            'total_debounced' => $this->totalDebounced,
             'success_rate' => $this->successRate,
             'failure_rate' => $this->failureRate,
         ];

--- a/src/Events/JobMetricsDebounced.php
+++ b/src/Events/JobMetricsDebounced.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired when a debounced job is detected and discarded.
+ * The job was superseded by a newer dispatch and never executed.
+ */
+final class JobMetricsDebounced
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $jobId,
+        public readonly string $jobClass,
+        public readonly string $connection,
+        public readonly string $queue,
+        public readonly ?string $hostname = null,
+    ) {}
+}

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -6,6 +6,7 @@ namespace Cbox\LaravelQueueMetrics;
 
 use Cbox\LaravelQueueMetrics\Actions\CalculateJobMetricsAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordJobCompletionAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordJobDebouncedAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordJobFailureAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordJobStartAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
@@ -20,6 +21,7 @@ use Cbox\LaravelQueueMetrics\Console\DetectStaleWorkersCommand;
 use Cbox\LaravelQueueMetrics\Console\RecordTrendDataCommand;
 use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
 use Cbox\LaravelQueueMetrics\Exceptions\ConfigurationException;
+use Cbox\LaravelQueueMetrics\Listeners\JobDebouncedListener;
 use Cbox\LaravelQueueMetrics\Listeners\JobExceptionOccurredListener;
 use Cbox\LaravelQueueMetrics\Listeners\JobFailedListener;
 use Cbox\LaravelQueueMetrics\Listeners\JobProcessedListener;
@@ -55,6 +57,7 @@ use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
 use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
 use Cbox\LaravelQueueMetrics\Utilities\PercentileCalculator;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Queue\Events\JobDebounced;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
@@ -180,6 +183,7 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             'record_queue_depth_history' => Actions\RecordQueueDepthHistoryAction::class,
             'record_throughput_history' => Actions\RecordThroughputHistoryAction::class,
             'calculate_baselines' => Actions\CalculateBaselinesAction::class,
+            'record_job_debounced' => RecordJobDebouncedAction::class,
         ]);
 
         foreach ($actions as $key => $actionClass) {
@@ -204,6 +208,11 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
         Event::listen(JobRetryRequested::class, JobRetryRequestedListener::class);
         Event::listen(JobTimedOut::class, JobTimedOutListener::class);
         Event::listen(JobExceptionOccurred::class, JobExceptionOccurredListener::class);
+
+        // Register debounce listener (Laravel 13.6+ only)
+        if (class_exists(JobDebounced::class)) {
+            Event::listen(JobDebounced::class, JobDebouncedListener::class);
+        }
 
         // Register worker lifecycle event listeners
         Event::listen(WorkerStopping::class, WorkerStoppingListener::class);

--- a/src/Listeners/JobDebouncedListener.php
+++ b/src/Listeners/JobDebouncedListener.php
@@ -11,6 +11,7 @@ use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
 use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
 use Cbox\SystemMetrics\ProcessMetrics;
+use Illuminate\Contracts\Queue\Job;
 
 /**
  * Listen for debounced (superseded) jobs.
@@ -30,9 +31,13 @@ final readonly class JobDebouncedListener
         private RecordWorkerHeartbeatAction $recordWorkerHeartbeat,
     ) {}
 
+    /**
+     * @param  object{connectionName: string, job: Job, command: mixed}  $event
+     */
     public function handle(object $event): void
     {
-        $job = $event->job;
+        /** @var Job $job */
+        $job = $event->job; // @phpstan-ignore property.notFound
         $payload = $job->payload();
         $jobId = (string) $job->getJobId();
 
@@ -43,7 +48,8 @@ final readonly class JobDebouncedListener
         $trackerId = "job_{$jobId}";
         ProcessMetrics::stop($trackerId);
 
-        $connection = $event->connectionName;
+        /** @var string $connection */
+        $connection = $event->connectionName; // @phpstan-ignore property.notFound
         $queue = $job->getQueue();
         $hostname = gethostname() ?: 'unknown';
         $jobClass = $payload['displayName'] ?? 'UnknownJob';

--- a/src/Listeners/JobDebouncedListener.php
+++ b/src/Listeners/JobDebouncedListener.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Listeners;
+
+use Cbox\LaravelQueueMetrics\Actions\RecordJobDebouncedAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
+use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
+use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
+use Cbox\SystemMetrics\ProcessMetrics;
+
+/**
+ * Listen for debounced (superseded) jobs.
+ *
+ * When a debounced job is discarded at execution time, this listener:
+ * 1. Marks the job so JobProcessedListener skips performance metrics
+ * 2. Stops the ProcessMetrics tracker started by JobProcessingListener
+ * 3. Records a total_debounced counter
+ * 4. Fires a downstream event for consumers
+ *
+ * Requires Laravel 13.6+ (Illuminate\Queue\Events\JobDebounced).
+ */
+final readonly class JobDebouncedListener
+{
+    public function __construct(
+        private RecordJobDebouncedAction $recordJobDebounced,
+        private RecordWorkerHeartbeatAction $recordWorkerHeartbeat,
+    ) {}
+
+    public function handle(object $event): void
+    {
+        $job = $event->job;
+        $payload = $job->payload();
+        $jobId = (string) $job->getJobId();
+
+        // Mark this job so JobProcessedListener skips performance metrics
+        DebouncedJobTracker::mark($jobId);
+
+        // Stop process metrics tracker (cleanup from JobProcessingListener)
+        $trackerId = "job_{$jobId}";
+        ProcessMetrics::stop($trackerId);
+
+        $connection = $event->connectionName;
+        $queue = $job->getQueue();
+        $hostname = gethostname() ?: 'unknown';
+        $jobClass = $payload['displayName'] ?? 'UnknownJob';
+
+        if (config('queue-metrics.persistence.enabled', true)) {
+            $this->recordJobDebounced->execute(
+                jobId: $jobId,
+                jobClass: $jobClass,
+                connection: $connection,
+                queue: $queue,
+            );
+
+            // Record worker heartbeat as IDLE (debounced job is done)
+            $workerId = HorizonDetector::generateWorkerId();
+            $this->recordWorkerHeartbeat->execute(
+                workerId: $workerId,
+                connection: $connection,
+                queue: $queue,
+                state: WorkerState::IDLE,
+                currentJobId: null,
+                currentJobClass: null,
+            );
+        }
+
+        // Fire downstream event (always, regardless of persistence setting)
+        JobMetricsDebounced::dispatch(
+            $jobId,
+            $jobClass,
+            $connection,
+            $queue,
+            $hostname,
+        );
+    }
+}

--- a/src/Listeners/JobProcessedListener.php
+++ b/src/Listeners/JobProcessedListener.php
@@ -8,6 +8,7 @@ use Cbox\LaravelQueueMetrics\Actions\RecordJobCompletionAction;
 use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
 use Cbox\LaravelQueueMetrics\Enums\WorkerState;
 use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
+use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
 use Cbox\LaravelQueueMetrics\Utilities\MemoryLimitParser;
 use Cbox\SystemMetrics\ProcessMetrics;
@@ -28,6 +29,12 @@ final readonly class JobProcessedListener
         $job = $event->job;
         $payload = $job->payload();
         $jobId = (string) $job->getJobId();
+
+        // Skip performance metrics for debounced (superseded) jobs.
+        // The JobDebouncedListener already recorded the debounce counter.
+        if (DebouncedJobTracker::wasDebounced($jobId)) {
+            return;
+        }
 
         // Calculate duration
         $startTime = $payload['pushedAt'] ?? microtime(true);

--- a/src/Repositories/Contracts/JobMetricsRepository.php
+++ b/src/Repositories/Contracts/JobMetricsRepository.php
@@ -51,6 +51,17 @@ interface JobMetricsRepository
     ): void;
 
     /**
+     * Record a debounced (superseded) job event.
+     */
+    public function recordDebounced(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $debouncedAt,
+    ): void;
+
+    /**
      * Get hostname-scoped job metrics for a specific server.
      *
      * @return array<string, array{total_processed: int, total_failed: int, total_duration_ms: float, failure_rate: float, avg_duration_ms: float}>

--- a/src/Repositories/DatabaseJobMetricsRepository.php
+++ b/src/Repositories/DatabaseJobMetricsRepository.php
@@ -214,6 +214,29 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
         }
     }
 
+    public function recordDebounced(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $debouncedAt,
+    ): void {
+        $metricsKey = $this->store->key('jobs', $connection, $queue, $jobClass);
+        $jobKey = $this->store->key('job', (string) $jobId);
+        $ttl = $this->store->getTtl('raw');
+
+        $driver = $this->store->driver();
+
+        $this->store->transaction(function () use ($driver, $metricsKey, $jobKey, $debouncedAt, $ttl) {
+            $driver->incrementHashField($metricsKey, 'total_debounced', 1);
+            $driver->setHash($metricsKey, ['last_debounced_at' => $debouncedAt->timestamp]);
+            $driver->expire($metricsKey, $ttl);
+
+            // Clean up job tracking key (started in recordStart)
+            $driver->delete($jobKey);
+        });
+    }
+
     /**
      * @return array<string, array{total_processed: int, total_failed: int, total_duration_ms: float, failure_rate: float, avg_duration_ms: float}>
      */
@@ -277,6 +300,10 @@ final readonly class DatabaseJobMetricsRepository implements JobMetricsRepositor
         return [
             'total_processed' => (int) ($data['total_processed'] ?? 0),
             'total_failed' => (int) ($data['total_failed'] ?? 0),
+            'total_debounced' => (int) ($data['total_debounced'] ?? 0),
+            'last_debounced_at' => isset($data['last_debounced_at'])
+                ? Carbon::createFromTimestamp((int) $data['last_debounced_at'])
+                : null,
             'total_duration_ms' => (float) ($data['total_duration_ms'] ?? 0.0),
             'total_memory_mb' => (float) ($data['total_memory_mb'] ?? 0.0),
             'total_cpu_time_ms' => (float) ($data['total_cpu_time_ms'] ?? 0.0),

--- a/src/Repositories/RedisJobMetricsRepository.php
+++ b/src/Repositories/RedisJobMetricsRepository.php
@@ -210,6 +210,27 @@ final readonly class RedisJobMetricsRepository implements JobMetricsRepository
         }
     }
 
+    public function recordDebounced(
+        string|int $jobId,
+        string $jobClass,
+        string $connection,
+        string $queue,
+        Carbon $debouncedAt,
+    ): void {
+        $metricsKey = $this->redis->key('jobs', $connection, $queue, $jobClass);
+        $jobKey = $this->redis->key('job', (string) $jobId);
+        $ttl = $this->redis->getTtl('raw');
+
+        $this->redis->transaction(function ($pipe) use ($metricsKey, $jobKey, $debouncedAt, $ttl) {
+            $pipe->incrementHashField($metricsKey, 'total_debounced', 1);
+            $pipe->setHash($metricsKey, ['last_debounced_at' => $debouncedAt->timestamp]);
+            $pipe->expire($metricsKey, $ttl);
+
+            // Clean up job tracking key (started in recordStart)
+            $pipe->delete($jobKey);
+        });
+    }
+
     /**
      * Record hostname-scoped job metrics for server-level aggregation.
      */
@@ -307,6 +328,10 @@ final readonly class RedisJobMetricsRepository implements JobMetricsRepository
         return [
             'total_processed' => (int) ($data['total_processed'] ?? 0),
             'total_failed' => (int) ($data['total_failed'] ?? 0),
+            'total_debounced' => (int) ($data['total_debounced'] ?? 0),
+            'last_debounced_at' => isset($data['last_debounced_at'])
+                ? Carbon::createFromTimestamp((int) $data['last_debounced_at'])
+                : null,
             'total_duration_ms' => (float) ($data['total_duration_ms'] ?? 0.0),
             'total_memory_mb' => (float) ($data['total_memory_mb'] ?? 0.0),
             'total_cpu_time_ms' => (float) ($data['total_cpu_time_ms'] ?? 0.0),

--- a/src/Services/PrometheusService.php
+++ b/src/Services/PrometheusService.php
@@ -170,7 +170,7 @@ final readonly class PrometheusService
             /** @var array{avg: float, min: float, max: float, peak: float, p95: float, p99: float}|null $memory */
             $memory = $jobData['memory'] ?? null;
 
-            /** @var array{success_count: int, failure_count: int, success_rate: float, failure_rate: float}|null $execution */
+            /** @var array{success_count: int, failure_count: int, total_debounced: int, success_rate: float, failure_rate: float}|null $execution */
             $execution = $jobData['execution'] ?? null;
 
             /** @var array{per_minute: float, per_hour: float, per_day: float}|null $throughput */
@@ -298,6 +298,18 @@ final readonly class PrometheusService
                     ->label('connection')
                     ->helpText('Job failure rate percentage')
                     ->value($execution['failure_rate'] * 100, [$job, $queue, $connection]);
+
+                // Debounced jobs counter
+                $debouncedCount = (int) ($execution['total_debounced'] ?? 0);
+
+                Prometheus::addCounter('job_debounced_total')
+                    ->name('job_debounced_total')
+                    ->namespace($namespace)
+                    ->label('job')
+                    ->label('queue')
+                    ->label('connection')
+                    ->helpText('Total number of debounced (superseded) jobs')
+                    ->setInitialValue($debouncedCount, [$job, $queue, $connection]);
             }
 
             // Throughput metrics

--- a/src/Services/PrometheusService.php
+++ b/src/Services/PrometheusService.php
@@ -170,7 +170,7 @@ final readonly class PrometheusService
             /** @var array{avg: float, min: float, max: float, peak: float, p95: float, p99: float}|null $memory */
             $memory = $jobData['memory'] ?? null;
 
-            /** @var array{success_count: int, failure_count: int, total_debounced: int, success_rate: float, failure_rate: float}|null $execution */
+            /** @var array{success_count: int, failure_count: int, total_debounced?: int, success_rate: float, failure_rate: float}|null $execution */
             $execution = $jobData['execution'] ?? null;
 
             /** @var array{per_minute: float, per_hour: float, per_day: float}|null $throughput */

--- a/src/Services/WorkerMetricsQueryService.php
+++ b/src/Services/WorkerMetricsQueryService.php
@@ -176,7 +176,7 @@ final readonly class WorkerMetricsQueryService
 
         // Group workers by hostname
         foreach ($heartbeats as $heartbeat) {
-            $hostname = $heartbeat->hostname ?? 'unknown';
+            $hostname = $heartbeat->hostname;
 
             if (! isset($servers[$hostname])) {
                 $servers[$hostname] = [

--- a/src/Support/DebouncedJobTracker.php
+++ b/src/Support/DebouncedJobTracker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Support;
+
+/**
+ * In-process tracker for debounced jobs.
+ *
+ * Allows JobDebouncedListener to mark a job ID, and JobProcessedListener
+ * to check and consume that mark. The mark is auto-consumed on read
+ * to prevent memory leaks in long-running workers.
+ */
+final class DebouncedJobTracker
+{
+    /** @var array<string, true> */
+    private static array $debouncedJobIds = [];
+
+    public static function mark(string $jobId): void
+    {
+        self::$debouncedJobIds[$jobId] = true;
+    }
+
+    /**
+     * Check if a job was debounced and consume the mark.
+     */
+    public static function wasDebounced(string $jobId): bool
+    {
+        if (isset(self::$debouncedJobIds[$jobId])) {
+            unset(self::$debouncedJobIds[$jobId]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function flush(): void
+    {
+        self::$debouncedJobIds = [];
+    }
+}

--- a/tests/Feature/ChildProcessTrackingTest.php
+++ b/tests/Feature/ChildProcessTrackingTest.php
@@ -45,7 +45,7 @@ it('tracks child processes when job spawns subprocesses', function () {
     $stats = $statsResult->getValue();
 
     // Verify metrics are calculated correctly as in JobProcessedListener
-    $memoryMb = $stats->peak->memoryRssBytes / 1024 / 1024;
+    $memoryMb = (float) ($stats->peak->memoryRssBytes / 1024 / 1024);
     expect($memoryMb)->toBeGreaterThan(0.0);
 
     $cpuUsagePercent = $stats->delta->cpuUsagePercentage();
@@ -160,7 +160,7 @@ it('provides process resource usage compatible with JobProcessedListener calcula
     $stats = $statsResult->getValue();
 
     // This is exactly how JobProcessedListener uses the metrics:
-    $memoryMb = $stats->peak->memoryRssBytes / 1024 / 1024;
+    $memoryMb = (float) ($stats->peak->memoryRssBytes / 1024 / 1024);
     $cpuUsagePercent = $stats->delta->cpuUsagePercentage();
     $durationSeconds = $stats->delta->durationSeconds;
     $cpuTimeMs = ($cpuUsagePercent / 100.0) * $durationSeconds * 1000.0;

--- a/tests/Unit/Actions/RecordJobDebouncedActionTest.php
+++ b/tests/Unit/Actions/RecordJobDebouncedActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Actions\RecordJobDebouncedAction;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+
+beforeEach(function () {
+    $this->repository = Mockery::mock(JobMetricsRepository::class);
+    $this->action = new RecordJobDebouncedAction($this->repository);
+
+    Carbon::setTestNow('2024-01-15 10:30:00');
+    config(['queue-metrics.enabled' => true]);
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+    Mockery::close();
+});
+
+it('records debounced job with all parameters', function () {
+    $this->repository->shouldReceive('recordDebounced')
+        ->once()
+        ->with(
+            'job-123',
+            'App\Jobs\ProcessOrder',
+            'redis',
+            'default',
+            Mockery::type(Carbon::class),
+        );
+
+    $this->action->execute(
+        jobId: 'job-123',
+        jobClass: 'App\Jobs\ProcessOrder',
+        connection: 'redis',
+        queue: 'default',
+    );
+})->group('functional');
+
+it('does nothing when metrics are disabled', function () {
+    config(['queue-metrics.enabled' => false]);
+
+    $this->repository->shouldNotReceive('recordDebounced');
+
+    $this->action->execute(
+        jobId: 'job-123',
+        jobClass: 'App\Jobs\ProcessOrder',
+        connection: 'redis',
+        queue: 'default',
+    );
+})->group('functional');

--- a/tests/Unit/Events/JobMetricsDebouncedTest.php
+++ b/tests/Unit/Events/JobMetricsDebouncedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake([JobMetricsDebounced::class]);
+});
+
+it('can be dispatched with debounced job data', function () {
+    JobMetricsDebounced::dispatch(
+        'job-123',
+        'App\Jobs\ProcessOrder',
+        'redis',
+        'default',
+        'worker-01',
+    );
+
+    Event::assertDispatched(JobMetricsDebounced::class, function ($event) {
+        return $event->jobId === 'job-123'
+            && $event->jobClass === 'App\Jobs\ProcessOrder'
+            && $event->connection === 'redis'
+            && $event->queue === 'default'
+            && $event->hostname === 'worker-01';
+    });
+})->group('functional');
+
+it('contains all debounced job data', function () {
+    $event = new JobMetricsDebounced(
+        jobId: 'job-456',
+        jobClass: 'App\Jobs\SendEmail',
+        connection: 'sqs',
+        queue: 'emails',
+        hostname: 'worker-02',
+    );
+
+    expect($event->jobId)->toBe('job-456')
+        ->and($event->jobClass)->toBe('App\Jobs\SendEmail')
+        ->and($event->connection)->toBe('sqs')
+        ->and($event->queue)->toBe('emails')
+        ->and($event->hostname)->toBe('worker-02');
+})->group('functional');
+
+it('allows null hostname', function () {
+    $event = new JobMetricsDebounced(
+        jobId: 'job-789',
+        jobClass: 'App\Jobs\TestJob',
+        connection: 'redis',
+        queue: 'default',
+    );
+
+    expect($event->hostname)->toBeNull();
+})->group('functional');
+
+it('is dispatchable using trait', function () {
+    expect(class_uses(JobMetricsDebounced::class))
+        ->toContain('Illuminate\Foundation\Events\Dispatchable');
+})->group('functional');

--- a/tests/Unit/Listeners/JobDebouncedListenerTest.php
+++ b/tests/Unit/Listeners/JobDebouncedListenerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Actions\RecordJobDebouncedAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
+use Cbox\LaravelQueueMetrics\Enums\WorkerState;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Cbox\LaravelQueueMetrics\Listeners\JobDebouncedListener;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    DebouncedJobTracker::flush();
+
+    $this->jobMetricsRepository = Mockery::mock(JobMetricsRepository::class);
+    $this->workerHeartbeatRepository = Mockery::mock(WorkerHeartbeatRepository::class);
+
+    $this->recordDebounced = new RecordJobDebouncedAction($this->jobMetricsRepository);
+    $this->recordHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+
+    $this->listener = new JobDebouncedListener(
+        $this->recordDebounced,
+        $this->recordHeartbeat,
+    );
+
+    config([
+        'queue-metrics.enabled' => true,
+        'queue-metrics.persistence.enabled' => true,
+    ]);
+});
+
+afterEach(function () {
+    DebouncedJobTracker::flush();
+    Mockery::close();
+});
+
+it('marks the job as debounced in the tracker', function () {
+    Event::fake([JobMetricsDebounced::class]);
+
+    $event = createDebouncedEvent('job-123', 'App\Jobs\SyncData', 'redis', 'default');
+
+    $this->jobMetricsRepository->shouldReceive('recordDebounced')->once();
+    $this->workerHeartbeatRepository->shouldReceive('recordHeartbeat')->once();
+
+    $this->listener->handle($event);
+
+    // DebouncedJobTracker::mark() was called, but wasDebounced() hasn't been
+    // called yet so the mark should still be there
+    expect(DebouncedJobTracker::wasDebounced('job-123'))->toBeTrue();
+})->group('functional');
+
+it('records debounced metric via repository', function () {
+    Event::fake([JobMetricsDebounced::class]);
+
+    $event = createDebouncedEvent('job-456', 'App\Jobs\ProcessOrder', 'redis', 'orders');
+
+    $this->jobMetricsRepository->shouldReceive('recordDebounced')
+        ->once()
+        ->with(
+            'job-456',
+            'App\Jobs\ProcessOrder',
+            'redis',
+            'orders',
+            Mockery::type(Carbon::class),
+        );
+
+    $this->workerHeartbeatRepository->shouldReceive('recordHeartbeat')->once();
+
+    $this->listener->handle($event);
+})->group('functional');
+
+it('dispatches JobMetricsDebounced event', function () {
+    Event::fake([JobMetricsDebounced::class]);
+
+    $event = createDebouncedEvent('job-789', 'App\Jobs\SendEmail', 'sqs', 'emails');
+
+    $this->jobMetricsRepository->shouldReceive('recordDebounced')->once();
+    $this->workerHeartbeatRepository->shouldReceive('recordHeartbeat')->once();
+
+    $this->listener->handle($event);
+
+    Event::assertDispatched(JobMetricsDebounced::class, function ($e) {
+        return $e->jobId === 'job-789'
+            && $e->jobClass === 'App\Jobs\SendEmail'
+            && $e->connection === 'sqs'
+            && $e->queue === 'emails';
+    });
+})->group('functional');
+
+it('records worker heartbeat as idle', function () {
+    Event::fake([JobMetricsDebounced::class]);
+
+    $event = createDebouncedEvent('job-abc', 'App\Jobs\Test', 'redis', 'default');
+
+    $this->jobMetricsRepository->shouldReceive('recordDebounced')->once();
+
+    $this->workerHeartbeatRepository->shouldReceive('recordHeartbeat')
+        ->once()
+        ->withArgs(function ($workerId, $connection, $queue, $state) {
+            return is_string($workerId)
+                && $connection === 'redis'
+                && $queue === 'default'
+                && $state === WorkerState::IDLE;
+        });
+
+    $this->listener->handle($event);
+})->group('functional');
+
+it('skips persistence when disabled', function () {
+    Event::fake([JobMetricsDebounced::class]);
+    config(['queue-metrics.persistence.enabled' => false]);
+
+    $event = createDebouncedEvent('job-skip', 'App\Jobs\Test', 'redis', 'default');
+
+    $this->jobMetricsRepository->shouldNotReceive('recordDebounced');
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $this->listener->handle($event);
+
+    // Event should still be dispatched (it's for downstream consumers, not persistence)
+    Event::assertDispatched(JobMetricsDebounced::class);
+})->group('functional');
+
+/**
+ * Helper to create a JobDebounced-like event object.
+ * Since Illuminate\Queue\Events\JobDebounced may not exist in test environment
+ * (Laravel < 13.6), we create a compatible anonymous class.
+ */
+function createDebouncedEvent(string $jobId, string $jobClass, string $connectionName, string $queue): object
+{
+    $job = Mockery::mock(QueueJob::class);
+    $job->shouldReceive('getJobId')->andReturn($jobId);
+    $job->shouldReceive('payload')->andReturn(['displayName' => $jobClass]);
+    $job->shouldReceive('getQueue')->andReturn($queue);
+
+    $command = new stdClass;
+
+    return new class($connectionName, $job, $command)
+    {
+        public function __construct(
+            public $connectionName,
+            public $job,
+            public $command,
+        ) {}
+    };
+}

--- a/tests/Unit/Listeners/JobProcessedListenerDebouncedTest.php
+++ b/tests/Unit/Listeners/JobProcessedListenerDebouncedTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Actions\RecordJobCompletionAction;
+use Cbox\LaravelQueueMetrics\Actions\RecordWorkerHeartbeatAction;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
+use Cbox\LaravelQueueMetrics\Listeners\JobProcessedListener;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\WorkerHeartbeatRepository;
+use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    DebouncedJobTracker::flush();
+
+    $this->jobMetricsRepository = Mockery::mock(JobMetricsRepository::class);
+    $this->workerHeartbeatRepository = Mockery::mock(WorkerHeartbeatRepository::class);
+
+    $this->recordCompletion = new RecordJobCompletionAction($this->jobMetricsRepository);
+    $this->recordHeartbeat = new RecordWorkerHeartbeatAction($this->workerHeartbeatRepository);
+
+    $this->listener = new JobProcessedListener(
+        $this->recordCompletion,
+        $this->recordHeartbeat,
+    );
+
+    config([
+        'queue-metrics.enabled' => true,
+        'queue-metrics.persistence.enabled' => true,
+    ]);
+});
+
+afterEach(function () {
+    DebouncedJobTracker::flush();
+    Mockery::close();
+});
+
+it('skips performance metrics for debounced jobs', function () {
+    Event::fake([JobMetricsCompleted::class]);
+
+    $job = Mockery::mock(QueueJob::class);
+    $job->shouldReceive('getJobId')->andReturn('job-debounced');
+    $job->shouldReceive('payload')->andReturn([
+        'displayName' => 'App\Jobs\SyncData',
+        'pushedAt' => microtime(true),
+    ]);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    DebouncedJobTracker::mark('job-debounced');
+
+    $event = new JobProcessed('redis', $job);
+
+    $this->jobMetricsRepository->shouldNotReceive('recordCompletion');
+    $this->workerHeartbeatRepository->shouldNotReceive('recordHeartbeat');
+
+    $this->listener->handle($event);
+
+    Event::assertNotDispatched(JobMetricsCompleted::class);
+})->group('functional');
+
+it('records performance metrics for normal jobs', function () {
+    Event::fake([JobMetricsCompleted::class]);
+
+    $job = Mockery::mock(QueueJob::class);
+    $job->shouldReceive('getJobId')->andReturn('job-normal');
+    $job->shouldReceive('payload')->andReturn([
+        'displayName' => 'App\Jobs\ProcessOrder',
+        'pushedAt' => microtime(true),
+    ]);
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    // NOT marked as debounced
+
+    $event = new JobProcessed('redis', $job);
+
+    $this->jobMetricsRepository->shouldReceive('recordCompletion')->once();
+    $this->workerHeartbeatRepository->shouldReceive('recordHeartbeat')->once();
+
+    $this->listener->handle($event);
+
+    Event::assertDispatched(JobMetricsCompleted::class);
+})->group('functional');

--- a/tests/Unit/Services/PrometheusServiceTest.php
+++ b/tests/Unit/Services/PrometheusServiceTest.php
@@ -199,3 +199,37 @@ test('it handles missing queue labels gracefully', function () {
     expect($metrics)->toContain('queue="unknown"');
     expect($metrics)->toContain('connection="unknown"');
 })->group('functional');
+
+test('it exports debounced job counter', function () {
+    config(['queue-metrics.prometheus.namespace' => 'test_namespace']);
+
+    $overview = Mockery::mock(OverviewQueryInterface::class);
+    $config = QueueMetricsConfig::fromConfig();
+
+    $overview->shouldReceive('getOverview')->andReturn([
+        'queues' => [],
+        'jobs' => [
+            'App\\Jobs\\SyncData' => [
+                'queue' => 'default',
+                'connection' => 'redis',
+                'execution' => [
+                    'success_count' => 100,
+                    'failure_count' => 5,
+                    'total_debounced' => 23,
+                    'success_rate' => 0.95,
+                    'failure_rate' => 0.05,
+                ],
+            ],
+        ],
+        'workers' => ['total' => 0, 'active' => 0, 'idle' => 0, 'avg_idle_percentage' => 0, 'total_jobs_processed' => 0],
+        'baselines' => [],
+    ]);
+
+    $service = new PrometheusService($overview, $config);
+    $service->exportMetrics();
+
+    $metrics = Prometheus::renderCollectors();
+
+    expect($metrics)->toContain('test_namespace_job_debounced_total');
+    expect($metrics)->toContain('job="App\\\\Jobs\\\\SyncData"');
+})->group('functional');

--- a/tests/Unit/Support/DebouncedJobTrackerTest.php
+++ b/tests/Unit/Support/DebouncedJobTrackerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Support\DebouncedJobTracker;
+
+beforeEach(function () {
+    DebouncedJobTracker::flush();
+});
+
+it('marks a job as debounced', function () {
+    DebouncedJobTracker::mark('job-123');
+
+    expect(DebouncedJobTracker::wasDebounced('job-123'))->toBeTrue();
+})->group('functional');
+
+it('returns false for unmarked jobs', function () {
+    expect(DebouncedJobTracker::wasDebounced('job-456'))->toBeFalse();
+})->group('functional');
+
+it('consumes the mark on check so it cannot be double-read', function () {
+    DebouncedJobTracker::mark('job-789');
+
+    expect(DebouncedJobTracker::wasDebounced('job-789'))->toBeTrue();
+    expect(DebouncedJobTracker::wasDebounced('job-789'))->toBeFalse();
+})->group('functional');
+
+it('tracks multiple jobs independently', function () {
+    DebouncedJobTracker::mark('job-a');
+    DebouncedJobTracker::mark('job-b');
+
+    expect(DebouncedJobTracker::wasDebounced('job-a'))->toBeTrue();
+    expect(DebouncedJobTracker::wasDebounced('job-b'))->toBeTrue();
+    expect(DebouncedJobTracker::wasDebounced('job-a'))->toBeFalse();
+})->group('functional');
+
+it('flushes all tracked jobs', function () {
+    DebouncedJobTracker::mark('job-x');
+    DebouncedJobTracker::mark('job-y');
+
+    DebouncedJobTracker::flush();
+
+    expect(DebouncedJobTracker::wasDebounced('job-x'))->toBeFalse();
+    expect(DebouncedJobTracker::wasDebounced('job-y'))->toBeFalse();
+})->group('functional');


### PR DESCRIPTION
## Summary

- Adds debounce metrics tracking for Laravel 13.6's new `#[DebounceFor]` job attribute
- Debounced (superseded) jobs are excluded from duration/memory/CPU percentiles and throughput — they never executed, so recording them would skew performance data
- Tracks `total_debounced` as a separate counter per job class, visible in API responses and Prometheus (`job_debounced_total`)
- Backward compatible: listener is conditionally registered only when `Illuminate\Queue\Events\JobDebounced` exists (Laravel 13.6+). No impact on Laravel 11/12.

## How it works

Laravel 13.6 fires `JobProcessing` → `JobDebounced` → `JobProcessed` for superseded jobs. Our new `JobDebouncedListener` intercepts `JobDebounced`, marks the job via a static tracker, records the debounce counter, and stops ProcessMetrics. When `JobProcessed` fires next, `JobProcessedListener` checks the tracker and returns early — no performance metrics are recorded.

## New files
- `src/Support/DebouncedJobTracker.php` — static inter-listener communication
- `src/Listeners/JobDebouncedListener.php` — core debounce handler
- `src/Actions/RecordJobDebouncedAction.php` — persistence action
- `src/Events/JobMetricsDebounced.php` — downstream event for consumers

## Test plan
- [x] 303 tests pass, 0 failures
- [x] DebouncedJobTracker: mark, consume, flush, independent tracking (5 tests)
- [x] JobDebouncedListener: persistence, event dispatch, heartbeat, disabled mode (5 tests)
- [x] JobProcessedListener: skips debounced, records normal (2 tests)
- [x] RecordJobDebouncedAction: records via repository, disabled check (2 tests)
- [x] JobMetricsDebounced event: dispatch, properties, null hostname (4 tests)
- [x] Prometheus: exports `job_debounced_total` counter (1 test)
- [x] Backward compatibility: `class_exists()` guard on listener registration
- [x] Pint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)