### PR TITLE
feat: add CPU time statistics to job metrics

### DIFF
--- a/docs/advanced-usage/architecture.md
+++ b/docs/advanced-usage/architecture.md
@@ -368,6 +368,7 @@ class JobMetricsQueryService
 - `QueueMetricsData` - Queue health data
 - `DurationStatsDTO` - Duration statistics
 - `MemoryStatsDTO` - Memory statistics
+- `CpuStatsDTO` - CPU time statistics
 - `ThroughputStatsDTO` - Throughput metrics
 - `HealthDataDTO` - Health assessment
 - `TrendDataDTO` - Trend analysis
@@ -393,6 +394,7 @@ final readonly class JobMetricsData
         public float $failureRate,
         public DurationStatsDTO $duration,
         public MemoryStatsDTO $memory,
+        public CpuStatsDTO $cpu,
         public ThroughputStatsDTO $throughput,
         public ?FailureInfoDTO $lastFailure,
         public ?TrendDataDTO $trend,

--- a/docs/basic-usage/api-endpoints.md
+++ b/docs/basic-usage/api-endpoints.md
@@ -225,6 +225,7 @@ Get aggregated metrics for a specific job class across all queues where it has e
         "total_failures": 25,
         "avg_duration_ms": 1250.50,
         "avg_memory_mb": 45.25,
+        "avg_cpu_time_ms": 850.00,
         "failure_rate": 2.5,
         "throughput_per_minute": 12.5,
         "by_queue": [
@@ -235,6 +236,7 @@ Get aggregated metrics for a specific job class across all queues where it has e
                 "failures": 15,
                 "avg_duration_ms": 1200.00,
                 "avg_memory_mb": 43.50,
+                "avg_cpu_time_ms": 800.00,
                 "failure_rate": 1.875,
                 "throughput_per_minute": 10.0
             },
@@ -245,6 +247,7 @@ Get aggregated metrics for a specific job class across all queues where it has e
                 "failures": 8,
                 "avg_duration_ms": 1500.00,
                 "avg_memory_mb": 52.00,
+                "avg_cpu_time_ms": 1100.00,
                 "failure_rate": 5.33,
                 "throughput_per_minute": 2.0
             },
@@ -255,6 +258,7 @@ Get aggregated metrics for a specific job class across all queues where it has e
                 "failures": 2,
                 "avg_duration_ms": 1100.00,
                 "avg_memory_mb": 40.00,
+                "avg_cpu_time_ms": 750.00,
                 "failure_rate": 4.0,
                 "throughput_per_minute": 0.5
             }
@@ -272,6 +276,7 @@ Get aggregated metrics for a specific job class across all queues where it has e
 - `total_failures` - Sum of failures across all queues
 - `avg_duration_ms` - Weighted average duration (weighted by execution count per queue)
 - `avg_memory_mb` - Weighted average memory usage (weighted by execution count per queue)
+- `avg_cpu_time_ms` - Weighted average CPU time in milliseconds (weighted by execution count per queue)
 - `failure_rate` - Percentage calculated as `(total_failures / total_executions) * 100`
 - `throughput_per_minute` - Sum of throughput across all queues
 - `calculated_at` - Timestamp when metrics were calculated
@@ -284,6 +289,7 @@ Each element contains metrics for a specific connection/queue combination where 
 - `failures` - Number of failures on this queue
 - `avg_duration_ms` - Average duration on this queue
 - `avg_memory_mb` - Average memory usage on this queue
+- `avg_cpu_time_ms` - Average CPU time in milliseconds on this queue
 - `failure_rate` - Failure rate percentage for this queue
 - `throughput_per_minute` - Jobs processed per minute on this queue
 
@@ -292,10 +298,11 @@ Each element contains metrics for a specific connection/queue combination where 
 The endpoint aggregates metrics across all queues where the job class has executed:
 
 1. **Totals**: `total_executions` and `total_failures` are simple sums across all queues
-2. **Weighted Averages**: `avg_duration_ms` and `avg_memory_mb` are calculated using weighted averages based on execution counts:
+2. **Weighted Averages**: `avg_duration_ms`, `avg_memory_mb`, and `avg_cpu_time_ms` are calculated using weighted averages based on execution counts:
    ```
    avg_duration = Σ(queue_duration × queue_executions) / total_executions
    avg_memory = Σ(queue_memory × queue_executions) / total_executions
+   avg_cpu_time = Σ(queue_cpu_time × queue_executions) / total_executions
    ```
 3. **Failure Rate**: Calculated from totals: `(total_failures / total_executions) * 100`
 4. **Throughput**: Sum of throughput across all queues (assumes non-overlapping time windows)

--- a/docs/basic-usage/facade-api.md
+++ b/docs/basic-usage/facade-api.md
@@ -73,6 +73,12 @@ $metrics->memory->peak;      // float: Peak memory usage
 $metrics->memory->p95;       // float: 95th percentile memory
 $metrics->memory->p99;       // float: 99th percentile memory
 
+// CPU time (CpuStats)
+$metrics->cpu->avg;          // float: Average CPU time in ms
+$metrics->cpu->peak;         // float: Peak CPU time
+$metrics->cpu->p95;          // float: 95th percentile CPU time
+$metrics->cpu->p99;          // float: 99th percentile CPU time
+
 // Throughput (ThroughputStats)
 $metrics->throughput->perMinute;  // float: Jobs per minute
 $metrics->throughput->perHour;    // float: Jobs per hour
@@ -95,6 +101,10 @@ $metrics = QueueMetrics::getJobMetrics(ProcessOrder::class);
 
 if ($metrics->duration->p95 > 5000) { // P95 >5 seconds
     Slack::send("⚠️ {$metrics->jobClass} is slow: P95 {$metrics->duration->p95}ms");
+}
+
+if ($metrics->cpu->p95 > 2000) { // P95 CPU time >2 seconds
+    Log::warning("High CPU usage for {$metrics->jobClass}: P95 {$metrics->cpu->p95}ms");
 }
 
 if ($metrics->execution->failureRate > 5) { // >5% failure rate
@@ -132,6 +142,7 @@ $allJobs = QueueMetrics::getAllJobsWithMetrics();
         'execution' => [...],
         'duration' => [...],
         'memory' => [...],
+        'cpu' => [...],
         'throughput' => [...],
         'failures' => [...],
         'window_stats' => [...],

--- a/src/Actions/CalculateJobMetricsAction.php
+++ b/src/Actions/CalculateJobMetricsAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMetrics\Actions;
 
 use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\CpuStats;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\DurationStats;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\FailureInfo;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\JobExecutionData;
@@ -41,6 +42,7 @@ final readonly class CalculateJobMetricsAction
             execution: $this->calculateExecution($metrics),
             duration: $this->calculateDuration($jobClass, $connection, $queue, $metrics),
             memory: $this->calculateMemory($jobClass, $connection, $queue),
+            cpu: $this->calculateCpu($jobClass, $connection, $queue),
             throughput: $this->calculateThroughput($jobClass, $connection, $queue),
             failures: $this->calculateFailures($metrics),
             windowStats: $this->calculateWindows($jobClass, $connection, $queue),
@@ -103,6 +105,27 @@ final readonly class CalculateJobMetricsAction
         $percentiles = $this->percentiles->calculateMultiple($samples, [95, 99]);
 
         return new MemoryStats(
+            avg: array_sum($samples) / count($samples),
+            peak: max($samples),
+            p95: $percentiles['p95'],
+            p99: $percentiles['p99'],
+        );
+    }
+
+    private function calculateCpu(
+        string $jobClass,
+        string $connection,
+        string $queue,
+    ): CpuStats {
+        $samples = $this->repository->getCpuTimeSamples($jobClass, $connection, $queue);
+
+        if (empty($samples)) {
+            return new CpuStats(0.0, 0.0, 0.0, 0.0);
+        }
+
+        $percentiles = $this->percentiles->calculateMultiple($samples, [95, 99]);
+
+        return new CpuStats(
             avg: array_sum($samples) / count($samples),
             peak: max($samples),
             p95: $percentiles['p95'],

--- a/src/DataTransferObjects/CpuStats.php
+++ b/src/DataTransferObjects/CpuStats.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\DataTransferObjects;
+
+/**
+ * CPU time statistics in milliseconds.
+ */
+final readonly class CpuStats
+{
+    public function __construct(
+        public float $avg,
+        public float $peak,
+        public float $p95,
+        public float $p99,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $avg = $data['avg'] ?? 0.0;
+        $peak = $data['peak'] ?? 0.0;
+        $p95 = $data['p95'] ?? 0.0;
+        $p99 = $data['p99'] ?? 0.0;
+
+        return new self(
+            avg: is_numeric($avg) ? (float) $avg : 0.0,
+            peak: is_numeric($peak) ? (float) $peak : 0.0,
+            p95: is_numeric($p95) ? (float) $p95 : 0.0,
+            p99: is_numeric($p99) ? (float) $p99 : 0.0,
+        );
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    public function toArray(): array
+    {
+        return [
+            'avg' => $this->avg,
+            'peak' => $this->peak,
+            'p95' => $this->p95,
+            'p99' => $this->p99,
+        ];
+    }
+}

--- a/src/DataTransferObjects/JobMetricsData.php
+++ b/src/DataTransferObjects/JobMetricsData.php
@@ -21,6 +21,7 @@ final readonly class JobMetricsData
         public JobExecutionData $execution,
         public DurationStats $duration,
         public MemoryStats $memory,
+        public CpuStats $cpu,
         public ThroughputStats $throughput,
         public FailureInfo $failures,
         public array $windowStats,
@@ -38,6 +39,7 @@ final readonly class JobMetricsData
         $execution = $data['execution'] ?? [];
         $duration = $data['duration'] ?? [];
         $memory = $data['memory'] ?? [];
+        $cpu = $data['cpu'] ?? [];
         $throughput = $data['throughput'] ?? [];
         $failures = $data['failures'] ?? [];
         $windowStatsData = $data['window_stats'] ?? [];
@@ -55,6 +57,7 @@ final readonly class JobMetricsData
             execution: JobExecutionData::fromArray(is_array($execution) ? $execution : []),
             duration: DurationStats::fromArray(is_array($duration) ? $duration : []),
             memory: MemoryStats::fromArray(is_array($memory) ? $memory : []),
+            cpu: CpuStats::fromArray(is_array($cpu) ? $cpu : []),
             throughput: ThroughputStats::fromArray(is_array($throughput) ? $throughput : []),
             failures: FailureInfo::fromArray(is_array($failures) ? $failures : []),
             windowStats: $windowStats,
@@ -76,6 +79,7 @@ final readonly class JobMetricsData
             'execution' => $this->execution->toArray(),
             'duration' => $this->duration->toArray(),
             'memory' => $this->memory->toArray(),
+            'cpu' => $this->cpu->toArray(),
             'throughput' => $this->throughput->toArray(),
             'failures' => $this->failures->toArray(),
             'window_stats' => array_map(

--- a/tests/Unit/DataTransferObjects/CpuStatsTest.php
+++ b/tests/Unit/DataTransferObjects/CpuStatsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\DataTransferObjects\CpuStats;
+
+describe('CpuStats', function () {
+    it('can be created with all properties', function () {
+        $stats = new CpuStats(
+            avg: 12.5,
+            peak: 45.0,
+            p95: 30.0,
+            p99: 40.0,
+        );
+
+        expect($stats->avg)->toBe(12.5)
+            ->and($stats->peak)->toBe(45.0)
+            ->and($stats->p95)->toBe(30.0)
+            ->and($stats->p99)->toBe(40.0);
+    });
+
+    it('can be converted to array', function () {
+        $stats = new CpuStats(
+            avg: 12.5,
+            peak: 45.0,
+            p95: 30.0,
+            p99: 40.0,
+        );
+
+        expect($stats->toArray())->toBe([
+            'avg' => 12.5,
+            'peak' => 45.0,
+            'p95' => 30.0,
+            'p99' => 40.0,
+        ]);
+    });
+
+    it('can be created from array', function () {
+        $data = [
+            'avg' => 12.5,
+            'peak' => 45.0,
+            'p95' => 30.0,
+            'p99' => 40.0,
+        ];
+
+        $stats = CpuStats::fromArray($data);
+
+        expect($stats)->toBeInstanceOf(CpuStats::class)
+            ->and($stats->avg)->toBe(12.5)
+            ->and($stats->peak)->toBe(45.0)
+            ->and($stats->p95)->toBe(30.0)
+            ->and($stats->p99)->toBe(40.0);
+    });
+
+    it('defaults missing keys to zero in fromArray', function () {
+        $stats = CpuStats::fromArray([]);
+
+        expect($stats->avg)->toBe(0.0)
+            ->and($stats->peak)->toBe(0.0)
+            ->and($stats->p95)->toBe(0.0)
+            ->and($stats->p99)->toBe(0.0);
+    });
+
+    it('handles non-numeric values in fromArray', function () {
+        $stats = CpuStats::fromArray([
+            'avg' => 'not-a-number',
+            'peak' => null,
+            'p95' => [],
+            'p99' => true,
+        ]);
+
+        expect($stats->avg)->toBe(0.0)
+            ->and($stats->peak)->toBe(0.0)
+            ->and($stats->p95)->toBe(0.0)
+            ->and($stats->p99)->toBe(0.0);
+    });
+
+    it('casts numeric strings in fromArray', function () {
+        $stats = CpuStats::fromArray([
+            'avg' => '12.5',
+            'peak' => '45',
+            'p95' => '30.0',
+            'p99' => '40.0',
+        ]);
+
+        expect($stats->avg)->toBe(12.5)
+            ->and($stats->peak)->toBe(45.0)
+            ->and($stats->p95)->toBe(30.0)
+            ->and($stats->p99)->toBe(40.0);
+    });
+
+    it('preserves zero values', function () {
+        $stats = new CpuStats(
+            avg: 0.0,
+            peak: 0.0,
+            p95: 0.0,
+            p99: 0.0,
+        );
+
+        expect($stats->toArray())->toBe([
+            'avg' => 0.0,
+            'peak' => 0.0,
+            'p95' => 0.0,
+            'p99' => 0.0,
+        ]);
+    });
+
+    it('roundtrips through toArray and fromArray', function () {
+        $original = new CpuStats(
+            avg: 15.75,
+            peak: 98.2,
+            p95: 85.0,
+            p99: 95.5,
+        );
+
+        $restored = CpuStats::fromArray($original->toArray());
+
+        expect($restored->avg)->toBe($original->avg)
+            ->and($restored->peak)->toBe($original->peak)
+            ->and($restored->p95)->toBe($original->p95)
+            ->and($restored->p99)->toBe($original->p99);
+    });
+
+    it('is readonly and immutable', function () {
+        $stats = new CpuStats(
+            avg: 12.5,
+            peak: 45.0,
+            p95: 30.0,
+            p99: 40.0,
+        );
+
+        expect(fn () => $stats->avg = 200.0)
+            ->toThrow(Error::class);
+    });
+});

--- a/tests/Unit/Events/MetricsRecordedTest.php
+++ b/tests/Unit/Events/MetricsRecordedTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\CpuStats;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\DurationStats;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\FailureInfo;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\JobExecutionData;
@@ -47,6 +48,12 @@ it('can be dispatched with job metrics data', function () {
             p95: 45.0,
             p99: 48.0,
         ),
+        cpu: new CpuStats(
+            avg: 12.5,
+            peak: 45.0,
+            p95: 30.0,
+            p99: 40.0,
+        ),
         throughput: new ThroughputStats(
             perMinute: 10.0,
             perHour: 600.0,
@@ -80,6 +87,7 @@ it('contains complete job metrics data', function () {
         execution: new JobExecutionData(48, 2, 96.0, 4.0),
         duration: new DurationStats(100.0, 80.0, 120.0, 95.0, 115.0, 118.0, 12.0),
         memory: new MemoryStats(30.0, 45.0, 42.0, 44.0),
+        cpu: new CpuStats(10.0, 35.0, 28.0, 33.0),
         throughput: new ThroughputStats(5.0, 300.0, 7200.0),
         failures: new FailureInfo(2, 4.0, null, null),
         windowStats: [],


### PR DESCRIPTION
## Summary

- Add `CpuStats` DTO to track CPU time statistics (avg, peak, p95, p99) in milliseconds
- Integrate CPU metric calculation into `CalculateJobMetricsAction` using repository CPU time samples and percentile calculations
- Include `cpu` field in `JobMetricsData` serialization/deserialization
- Add comprehensive unit tests for `CpuStats` (construction, array conversion, edge cases, immutability)
- Update `MetricsRecordedTest` to include CPU stats

## Test plan

- [ ] Verify `CpuStatsTest` passes all cases (construction, fromArray defaults, non-numeric handling, roundtrip)
- [ ] Verify `MetricsRecordedTest` passes with new CPU stats field
- [ ] Run full test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)