### PR TITLE
feat: optional OpenTelemetry integration via cboxdk/laravel-telemetry

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,6 +65,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          if [ "${{ matrix.laravel }}" = "11.*" ]; then
+            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
+          fi
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
@@ -130,6 +133,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          if [ "${{ matrix.laravel }}" = "11.*" ]; then
+            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
+          fi
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to `laravel-queue-metrics` will be documented in this file.
 ## v3.2.0 - Unreleased
 
 ### Added
+- Optional OpenTelemetry integration via `cboxdk/laravel-telemetry` (on by default when installed, `QUEUE_METRICS_TELEMETRY_ENABLED=false` to disable) — observable gauges for queue depth, oldest-job age, throughput, failure rate, active workers, worker counts/utilization and baselines, plus counters and structured OTLP events for health score changes, depth threshold breaches, debounced jobs, worker efficiency and baseline recalculations
+- `queue-metrics.telemetry` config block — master toggle, snapshot `cache_ttl`, per-gauge-group toggles and events toggle
+- `ProvidesTelemetrySnapshot` contract with cached default implementation — swap it to feed the telemetry gauges from a custom source
+- `queue-metrics:doctor` command — reports configuration state and warns when the built-in Prometheus exporter and the telemetry integration expose the same metrics twice
 - `memory.avg_incremental` field in job metrics output — reports incremental memory allocation (peak minus baseline) for job-class differentiation
 - `memoryIncrementalMb` parameter on `RecordJobCompletionAction::execute()`, repository contract, and job events
 - `job_memory_avg_incremental_megabytes` Prometheus gauge

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ Redis (fast, in-memory) or Database (persistent) backends with automatic TTL cle
 ### Prometheus Export
 Native Prometheus metrics endpoint for Grafana dashboards and alerting.
 
+### OpenTelemetry via laravel-telemetry
+When [cboxdk/laravel-telemetry](https://github.com/cboxdk/laravel-telemetry) is installed, queue metrics automatically publishes the state telemetry cannot see on its own — no configuration required (disable with `QUEUE_METRICS_TELEMETRY_ENABLED=false`):
+
+| Metric | Type | Unit | Labels |
+|---|---|---|---|
+| `queue_metrics.queue.depth` | gauge | `{jobs}` | `connection`, `queue`, `state` (pending/scheduled/reserved) |
+| `queue_metrics.queue.oldest_job.age` | gauge | `s` | `connection`, `queue` |
+| `queue_metrics.queue.throughput` | gauge | `{jobs}/min` | `connection`, `queue` |
+| `queue_metrics.queue.failure_rate` | gauge | `%` | `connection`, `queue` |
+| `queue_metrics.queue.active_workers` | gauge | `{workers}` | `connection`, `queue` |
+| `queue_metrics.queue.health_score` | gauge | `1` | `connection`, `queue` |
+| `queue_metrics.workers.count` | gauge | `{workers}` | `state` (busy/idle) |
+| `queue_metrics.workers.utilization` | gauge | `%` | `window` (current/lifetime) |
+| `queue_metrics.workers.efficiency` | gauge | `%` | — |
+| `queue_metrics.baseline.duration` | gauge | `ms` | `connection`, `queue` |
+| `queue_metrics.baseline.memory` | gauge | `MBy` | `connection`, `queue` |
+| `queue_metrics.baseline.cpu` | gauge | `%` | `connection`, `queue` |
+| `queue_metrics.baseline.confidence` | gauge | `1` | `connection`, `queue` |
+| `queue_metrics.health.changes` | counter | — | `connection`, `queue`, `severity` |
+| `queue_metrics.queue.depth_threshold.exceeded` | counter | — | `connection`, `queue` |
+| `queue_metrics.jobs.debounced` | counter | — | `job.name`, `queue` |
+| `queue_metrics.baseline.recalculations` | counter | — | `connection`, `queue`, `significant` |
+
+Severe health changes, depth threshold breaches and scaling recommendations are additionally emitted as structured OTLP events. Per-job durations, memory and outcome counters are deliberately **not** re-exported — laravel-telemetry's own queue instrumentation already covers those.
+
+Running both the built-in Prometheus exporter and the telemetry integration exposes the same queue state twice — `php artisan queue-metrics:doctor` diagnoses your setup and warns about double exposure.
+
 ### RESTful API
 Complete HTTP API for integration with custom dashboards and monitoring tools.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Redis (fast, in-memory) or Database (persistent) backends with automatic TTL cle
 Native Prometheus metrics endpoint for Grafana dashboards and alerting.
 
 ### OpenTelemetry via laravel-telemetry
-When [cboxdk/laravel-telemetry](https://github.com/cboxdk/laravel-telemetry) is installed, queue metrics automatically publishes the state telemetry cannot see on its own — no configuration required (disable with `QUEUE_METRICS_TELEMETRY_ENABLED=false`):
+When [cboxdk/laravel-telemetry](https://github.com/cboxdk/laravel-telemetry) is installed (requires Laravel 12+), queue metrics automatically publishes the state telemetry cannot see on its own — no configuration required (disable with `QUEUE_METRICS_TELEMETRY_ENABLED=false`):
 
 | Metric | Type | Unit | Labels |
 |---|---|---|---|

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "spatie/laravel-prometheus": "^1.3"
     },
     "require-dev": {
-        "cboxdk/laravel-telemetry": "^0.1.0@alpha",
+        "cboxdk/laravel-telemetry": "^0.2.0",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,10 @@
         "spatie/laravel-prometheus": "^1.3"
     },
     "require-dev": {
+        "cboxdk/laravel-telemetry": "^0.1.0@alpha",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
-        "larastan/larastan": "^3.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
@@ -38,6 +39,9 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"
+    },
+    "suggest": {
+        "cboxdk/laravel-telemetry": "Publishes queue depth, worker state and baseline gauges plus health/scaling events to OpenTelemetry & Prometheus via the telemetry pipeline."
     },
     "autoload": {
         "psr-4": {

--- a/config/queue-metrics.php
+++ b/config/queue-metrics.php
@@ -74,6 +74,43 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | 📡 TELEMETRY (cboxdk/laravel-telemetry)
+    |--------------------------------------------------------------------------
+    |
+    | When cboxdk/laravel-telemetry is installed, queue metrics automatically
+    | publishes observable gauges (queue depth, worker state, baselines) and
+    | pushes domain events (health changes, depth threshold breaches,
+    | debounced jobs) to it. Batteries included: on by default, no-op when
+    | the package is not installed.
+    |
+    | Tip: run `php artisan queue-metrics:doctor` — it warns when both this
+    | integration and the built-in Prometheus exporter are active, which
+    | would expose the same metrics twice.
+    |
+    */
+
+    'telemetry' => [
+        'enabled' => env('QUEUE_METRICS_TELEMETRY_ENABLED', true),
+
+        // Snapshot cache in seconds, so concurrent scrapes don't all scan
+        // the metrics store at once. 0 disables caching.
+        'cache_ttl' => env('QUEUE_METRICS_TELEMETRY_CACHE_TTL', 10),
+
+        // Observable gauge groups, evaluated at scrape time.
+        'gauges' => [
+            'queues' => true,
+            'workers' => true,
+            'baselines' => true,
+        ],
+
+        // Push counters/gauges/OTLP events from package domain events
+        // (health score changes, depth threshold breaches, debounces,
+        // worker efficiency, baseline recalculations).
+        'events' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | ⚙️ ADVANCED
     |--------------------------------------------------------------------------
     */

--- a/src/Console/DoctorCommand.php
+++ b/src/Console/DoctorCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Console;
+
+use Cbox\Telemetry\TelemetryManager;
+use Illuminate\Console\Command;
+
+/**
+ * Console command to diagnose queue metrics configuration and flag
+ * conflicting metric exposure setups.
+ */
+final class DoctorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'queue-metrics:doctor';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Diagnose queue metrics configuration and metric exposure';
+
+    public function handle(): int
+    {
+        $enabled = (bool) config('queue-metrics.enabled', true);
+
+        $this->components->twoColumnDetail('Queue metrics', $enabled ? '<info>enabled</info>' : '<comment>disabled</comment>');
+        $this->components->twoColumnDetail('Persistence', config('queue-metrics.persistence.enabled', true) ? '<info>enabled</info>' : '<comment>disabled</comment>');
+
+        $driver = config('queue-metrics.storage.driver', 'redis');
+        $this->components->twoColumnDetail('Storage driver', is_string($driver) ? $driver : 'unknown');
+
+        $prometheusEnabled = (bool) config('queue-metrics.prometheus.enabled', true);
+        $this->components->twoColumnDetail('Prometheus exporter', $prometheusEnabled ? '<info>enabled</info>' : '<comment>disabled</comment>');
+
+        $this->components->twoColumnDetail('Telemetry integration', $this->describeTelemetryIntegration());
+
+        if ($enabled && $prometheusEnabled && $this->telemetryIntegrationActive()) {
+            $this->newLine();
+            $this->components->warn(
+                'Queue metrics are exposed twice: the built-in Prometheus exporter and the '
+                .'cboxdk/laravel-telemetry integration are both active. Scraping both doubles '
+                .'storage and can skew dashboards. Disable one of them: set '
+                .'QUEUE_METRICS_PROMETHEUS_ENABLED=false (recommended when laravel-telemetry '
+                .'handles your metrics) or QUEUE_METRICS_TELEMETRY_ENABLED=false.'
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function describeTelemetryIntegration(): string
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            return '<comment>not installed</comment> (composer require cboxdk/laravel-telemetry)';
+        }
+
+        if (! $this->getLaravel()->bound(TelemetryManager::class)) {
+            return '<comment>inactive</comment> (telemetry service provider is not registered)';
+        }
+
+        if (! config('queue-metrics.telemetry.enabled', true)) {
+            return '<comment>disabled</comment> (queue-metrics.telemetry.enabled)';
+        }
+
+        if (! config('telemetry.enabled', true)) {
+            return '<comment>inactive</comment> (telemetry.enabled is false)';
+        }
+
+        if (! $this->telemetryPublishesAnything()) {
+            return '<comment>idle</comment> (all gauge and event toggles are off)';
+        }
+
+        return '<info>active</info>';
+    }
+
+    private function telemetryIntegrationActive(): bool
+    {
+        return class_exists(TelemetryManager::class)
+            && $this->getLaravel()->bound(TelemetryManager::class)
+            && (bool) config('queue-metrics.telemetry.enabled', true)
+            && (bool) config('telemetry.enabled', true)
+            && $this->telemetryPublishesAnything();
+    }
+
+    private function telemetryPublishesAnything(): bool
+    {
+        return (bool) config('queue-metrics.telemetry.events', true)
+            || (bool) config('queue-metrics.telemetry.gauges.queues', true)
+            || (bool) config('queue-metrics.telemetry.gauges.workers', true)
+            || (bool) config('queue-metrics.telemetry.gauges.baselines', true);
+    }
+}

--- a/src/LaravelQueueMetricsServiceProvider.php
+++ b/src/LaravelQueueMetricsServiceProvider.php
@@ -18,6 +18,7 @@ use Cbox\LaravelQueueMetrics\Config\StorageConfig;
 use Cbox\LaravelQueueMetrics\Console\CalculateQueueMetricsCommand;
 use Cbox\LaravelQueueMetrics\Console\CleanupDatabaseCommand;
 use Cbox\LaravelQueueMetrics\Console\DetectStaleWorkersCommand;
+use Cbox\LaravelQueueMetrics\Console\DoctorCommand;
 use Cbox\LaravelQueueMetrics\Console\RecordTrendDataCommand;
 use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
 use Cbox\LaravelQueueMetrics\Exceptions\ConfigurationException;
@@ -56,6 +57,7 @@ use Cbox\LaravelQueueMetrics\Services\WorkerMetricsQueryService;
 use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
 use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
 use Cbox\LaravelQueueMetrics\Utilities\PercentileCalculator;
+use Cbox\Telemetry\TelemetryManager;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Queue\Events\JobDebounced;
 use Illuminate\Queue\Events\JobExceptionOccurred;
@@ -85,6 +87,7 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
             ->hasCommand(CleanupDatabaseCommand::class)
             ->hasCommand(CleanupStaleWorkersCommand::class)
             ->hasCommand(DetectStaleWorkersCommand::class)
+            ->hasCommand(DoctorCommand::class)
             ->hasCommand(RecordTrendDataCommand::class);
     }
 
@@ -129,6 +132,12 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
 
         // Register utilities
         $this->app->singleton(PercentileCalculator::class);
+
+        // Snapshot source consumed by the optional telemetry integration
+        $this->app->singleton(
+            Telemetry\Contracts\ProvidesTelemetrySnapshot::class,
+            Telemetry\QueueMetricsTelemetrySnapshot::class,
+        );
     }
 
     /**
@@ -218,8 +227,38 @@ final class LaravelQueueMetricsServiceProvider extends PackageServiceProvider
         Event::listen(WorkerStopping::class, WorkerStoppingListener::class);
         Event::listen(Looping::class, LoopingListener::class);
 
+        // Publish to cboxdk/laravel-telemetry when it is installed
+        $this->registerTelemetryIntegration();
+
         // Register scheduled tasks
         $this->registerScheduledTasks();
+    }
+
+    /**
+     * Register the optional cboxdk/laravel-telemetry integration: an
+     * observable-gauge provider for stored queue/worker/baseline state and
+     * an event subscriber pushing counters and OTLP events. Guarded so the
+     * dependency stays optional and the integration can be disabled.
+     */
+    protected function registerTelemetryIntegration(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            return;
+        }
+
+        if (! config('queue-metrics.telemetry.enabled', true)) {
+            return;
+        }
+
+        if (! $this->app->bound(TelemetryManager::class)) {
+            return;
+        }
+
+        $this->app->make(TelemetryManager::class)->provider(
+            new Telemetry\QueueMetricsTelemetryProvider($this->app),
+        );
+
+        Event::subscribe(Telemetry\TelemetryEventSubscriber::class);
     }
 
     /**

--- a/src/Telemetry/Contracts/ProvidesTelemetrySnapshot.php
+++ b/src/Telemetry/Contracts/ProvidesTelemetrySnapshot.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Telemetry\Contracts;
+
+/**
+ * Supplies the stored metrics snapshot consumed by the telemetry
+ * observable gauges. Implementations must stay cheap: callbacks run on
+ * every telemetry scrape.
+ */
+interface ProvidesTelemetrySnapshot
+{
+    /**
+     * @return array{
+     *     queues: array<int|string, array<string, mixed>>,
+     *     workers: array<string, mixed>,
+     *     baselines: array<int|string, array<string, mixed>>
+     * }
+     */
+    public function snapshot(): array;
+}

--- a/src/Telemetry/QueueMetricsTelemetryProvider.php
+++ b/src/Telemetry/QueueMetricsTelemetryProvider.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Telemetry;
+
+use Cbox\LaravelQueueMetrics\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\Telemetry\Contracts\TelemetryProvider;
+use Cbox\Telemetry\Metrics\Registry;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Publishes queue-metrics state to cboxdk/laravel-telemetry as observable
+ * gauges, evaluated at scrape time from the stored metrics snapshot.
+ *
+ * Deliberately limited to what telemetry's own QueueInstrumentation cannot
+ * see (queue depth, worker state, baselines) — per-job durations, memory
+ * and outcome counters are already covered by telemetry itself.
+ */
+final readonly class QueueMetricsTelemetryProvider implements TelemetryProvider
+{
+    public function __construct(private Container $container) {}
+
+    public function name(): string
+    {
+        return 'cbox.queue-metrics';
+    }
+
+    public function register(Registry $registry): void
+    {
+        if (config('queue-metrics.telemetry.gauges.queues', true)) {
+            $this->registerQueueGauges($registry);
+        }
+
+        if (config('queue-metrics.telemetry.gauges.workers', true)) {
+            $this->registerWorkerGauges($registry);
+        }
+
+        if (config('queue-metrics.telemetry.gauges.baselines', true)) {
+            $this->registerBaselineGauges($registry);
+        }
+    }
+
+    private function registerQueueGauges(Registry $registry): void
+    {
+        $registry->gauge(
+            'queue_metrics.queue.depth',
+            fn (): array => $this->perQueue(fn (array $queue, array $labels): array => [
+                [$this->toFloat($this->nested($queue, 'depth', 'pending')), [...$labels, 'state' => 'pending']],
+                [$this->toFloat($this->nested($queue, 'depth', 'scheduled')), [...$labels, 'state' => 'scheduled']],
+                [$this->toFloat($this->nested($queue, 'depth', 'reserved')), [...$labels, 'state' => 'reserved']],
+            ]),
+            description: 'Queue depth by job state',
+            unit: '{jobs}',
+        );
+
+        $registry->gauge(
+            'queue_metrics.queue.oldest_job.age',
+            fn (): array => $this->perQueue(fn (array $queue, array $labels): array => [
+                [$this->toFloat($this->nested($queue, 'depth', 'oldest_job_age_seconds')), $labels],
+            ]),
+            description: 'Age of the oldest pending job',
+            unit: 's',
+        );
+
+        $registry->gauge(
+            'queue_metrics.queue.throughput',
+            fn (): array => $this->perQueue(fn (array $queue, array $labels): array => [
+                [$this->toFloat($this->nested($queue, 'performance_60s', 'throughput_per_minute')), $labels],
+            ]),
+            description: 'Jobs processed per minute (60s window)',
+            unit: '{jobs}/min',
+        );
+
+        $registry->gauge(
+            'queue_metrics.queue.failure_rate',
+            fn (): array => $this->perQueue(fn (array $queue, array $labels): array => [
+                [$this->toFloat($this->nested($queue, 'lifetime', 'failure_rate_percent')), $labels],
+            ]),
+            description: 'Lifetime job failure rate',
+            unit: '%',
+        );
+
+        $registry->gauge(
+            'queue_metrics.queue.active_workers',
+            fn (): array => $this->perQueue(fn (array $queue, array $labels): array => [
+                [$this->toFloat($this->nested($queue, 'workers', 'active_count')), $labels],
+            ]),
+            description: 'Workers currently attached to this queue',
+            unit: '{workers}',
+        );
+    }
+
+    private function registerWorkerGauges(Registry $registry): void
+    {
+        $registry->gauge(
+            'queue_metrics.workers.count',
+            function (): array {
+                $workers = $this->snapshot()['workers'];
+
+                return [
+                    [$this->toFloat($this->nested($workers, 'count', 'active')), ['state' => 'busy']],
+                    [$this->toFloat($this->nested($workers, 'count', 'idle')), ['state' => 'idle']],
+                ];
+            },
+            description: 'Queue workers by state',
+            unit: '{workers}',
+        );
+
+        $registry->gauge(
+            'queue_metrics.workers.utilization',
+            function (): array {
+                $workers = $this->snapshot()['workers'];
+
+                return [
+                    [$this->toFloat($this->nested($workers, 'utilization', 'current_busy_percent')), ['window' => 'current']],
+                    [$this->toFloat($this->nested($workers, 'utilization', 'lifetime_busy_percent')), ['window' => 'lifetime']],
+                ];
+            },
+            description: 'Worker busy percentage, current snapshot and lifetime',
+            unit: '%',
+        );
+    }
+
+    private function registerBaselineGauges(Registry $registry): void
+    {
+        $baselineGauges = [
+            'queue_metrics.baseline.duration' => ['avg_duration_ms', 'Baseline average job duration', 'ms'],
+            'queue_metrics.baseline.memory' => ['memory_mb_per_job', 'Baseline memory per job', 'MBy'],
+            'queue_metrics.baseline.cpu' => ['cpu_percent_per_job', 'Baseline CPU per job', '%'],
+            'queue_metrics.baseline.confidence' => ['confidence_score', 'Baseline confidence score (0-1)', '1'],
+        ];
+
+        foreach ($baselineGauges as $name => [$field, $description, $unit]) {
+            $registry->gauge(
+                $name,
+                fn (): array => $this->perBaseline(fn (array $baseline, array $labels): array => [
+                    [$this->toFloat($baseline[$field] ?? 0), $labels],
+                ]),
+                description: $description,
+                unit: $unit,
+            );
+        }
+    }
+
+    /**
+     * @param  callable(array<string, mixed>, array<string, string>): list<array{0: float, 1: array<string, string>}>  $samples
+     * @return list<array{0: float, 1: array<string, string>}>
+     */
+    private function perQueue(callable $samples): array
+    {
+        $result = [];
+
+        foreach ($this->snapshot()['queues'] as $queue) {
+            $labels = [
+                'connection' => $this->toLabel($queue['connection'] ?? 'default'),
+                'queue' => $this->toLabel($queue['queue'] ?? 'default'),
+            ];
+
+            $result = [...$result, ...$samples($queue, $labels)];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  callable(array<string, mixed>, array<string, string>): list<array{0: float, 1: array<string, string>}>  $samples
+     * @return list<array{0: float, 1: array<string, string>}>
+     */
+    private function perBaseline(callable $samples): array
+    {
+        $result = [];
+
+        foreach ($this->snapshot()['baselines'] as $baseline) {
+            $labels = [
+                'connection' => $this->toLabel($baseline['connection'] ?? 'default'),
+                'queue' => $this->toLabel($baseline['queue'] ?? 'default'),
+            ];
+
+            $jobClass = $baseline['job_class'] ?? '';
+
+            if (is_string($jobClass) && $jobClass !== '') {
+                $labels['job.name'] = $jobClass;
+            }
+
+            $result = [...$result, ...$samples($baseline, $labels)];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function nested(array $data, string $group, string $key): mixed
+    {
+        $section = $data[$group] ?? null;
+
+        return is_array($section) ? ($section[$key] ?? null) : null;
+    }
+
+    /**
+     * @return array{
+     *     queues: array<int|string, array<string, mixed>>,
+     *     workers: array<string, mixed>,
+     *     baselines: array<int|string, array<string, mixed>>
+     * }
+     */
+    private function snapshot(): array
+    {
+        return $this->container->make(ProvidesTelemetrySnapshot::class)->snapshot();
+    }
+
+    private function toFloat(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+
+    private function toLabel(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : 'unknown';
+    }
+}

--- a/src/Telemetry/QueueMetricsTelemetrySnapshot.php
+++ b/src/Telemetry/QueueMetricsTelemetrySnapshot.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Telemetry;
+
+use Cbox\LaravelQueueMetrics\DataTransferObjects\BaselineData;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\BaselineRepository;
+use Cbox\LaravelQueueMetrics\Services\QueueMetricsQueryService;
+use Cbox\LaravelQueueMetrics\Services\WorkerMetricsQueryService;
+use Cbox\LaravelQueueMetrics\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Default snapshot source backed by the stored queue metrics.
+ *
+ * The snapshot is cached briefly (like the Prometheus exporter) so
+ * concurrent scrapes do not all scan the metrics store at once.
+ */
+final class QueueMetricsTelemetrySnapshot implements ProvidesTelemetrySnapshot
+{
+    /**
+     * @var array{queues: array<int|string, array<string, mixed>>, workers: array<string, mixed>, baselines: array<int|string, array<string, mixed>>}|null
+     */
+    private ?array $memo = null;
+
+    private float $memoAt = 0.0;
+
+    public function __construct(private readonly Container $container) {}
+
+    /**
+     * @return array{
+     *     queues: array<int|string, array<string, mixed>>,
+     *     workers: array<string, mixed>,
+     *     baselines: array<int|string, array<string, mixed>>
+     * }
+     */
+    public function snapshot(): array
+    {
+        $cacheTtl = config('queue-metrics.telemetry.cache_ttl', 10);
+        $cacheTtl = is_numeric($cacheTtl) ? (int) $cacheTtl : 10;
+
+        if ($cacheTtl <= 0) {
+            // Every observable gauge callback calls snapshot() during a
+            // single scrape. Even with the shared cache disabled, one
+            // scrape must not rebuild per gauge — memoize briefly within
+            // this process instead.
+            if ($this->memo !== null && (microtime(true) - $this->memoAt) < 1.0) {
+                return $this->memo;
+            }
+
+            $this->memoAt = microtime(true);
+
+            return $this->memo = $this->build();
+        }
+
+        /** @var array{queues: array<int|string, array<string, mixed>>, workers: array<string, mixed>, baselines: array<int|string, array<string, mixed>>} */
+        return Cache::remember(
+            'queue_metrics:telemetry:snapshot',
+            now()->addSeconds($cacheTtl),
+            fn (): array => $this->build(),
+        );
+    }
+
+    /**
+     * @return array{
+     *     queues: array<int|string, array<string, mixed>>,
+     *     workers: array<string, mixed>,
+     *     baselines: array<int|string, array<string, mixed>>
+     * }
+     */
+    private function build(): array
+    {
+        $queueService = $this->container->make(QueueMetricsQueryService::class);
+        $workerService = $this->container->make(WorkerMetricsQueryService::class);
+
+        $queues = array_values($queueService->getAllQueuesWithMetrics());
+        $workers = $workerService->getWorkersSummary();
+
+        return [
+            'queues' => $queues,
+            'workers' => $workers,
+            'baselines' => $this->baselines($queues),
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $queues
+     * @return array<int, array<string, mixed>>
+     */
+    private function baselines(array $queues): array
+    {
+        if ($queues === [] || ! config('queue-metrics.telemetry.gauges.baselines', true)) {
+            return [];
+        }
+
+        $pairs = array_map(fn (array $queue): array => [
+            'connection' => is_string($queue['connection'] ?? null) ? $queue['connection'] : 'default',
+            'queue' => is_string($queue['queue'] ?? null) ? $queue['queue'] : 'default',
+        ], $queues);
+
+        $baselines = $this->container->make(BaselineRepository::class)->getBaselines($pairs);
+
+        return array_values(array_map(
+            fn (BaselineData $baseline): array => $baseline->toArray(),
+            $baselines,
+        ));
+    }
+}

--- a/src/Telemetry/TelemetryEventSubscriber.php
+++ b/src/Telemetry/TelemetryEventSubscriber.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Telemetry;
+
+use Cbox\LaravelQueueMetrics\Events\BaselineRecalculated;
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Cbox\LaravelQueueMetrics\Events\QueueDepthThresholdExceeded;
+use Cbox\LaravelQueueMetrics\Events\WorkerEfficiencyChanged;
+use Cbox\Telemetry\TelemetryManager;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Pushes queue-metrics domain events into cboxdk/laravel-telemetry as
+ * counters, gauges and structured OTLP events.
+ *
+ * The manager is resolved per event so Telemetry::fake() swaps take
+ * effect, and rare-but-important signals flush immediately — the
+ * long-running processes dispatching them have no request terminate.
+ */
+final readonly class TelemetryEventSubscriber
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @return array<class-string, string>
+     */
+    public function subscribe(): array
+    {
+        return [
+            HealthScoreChanged::class => 'handleHealthScoreChanged',
+            QueueDepthThresholdExceeded::class => 'handleQueueDepthThresholdExceeded',
+            JobMetricsDebounced::class => 'handleJobMetricsDebounced',
+            WorkerEfficiencyChanged::class => 'handleWorkerEfficiencyChanged',
+            BaselineRecalculated::class => 'handleBaselineRecalculated',
+        ];
+    }
+
+    public function handleHealthScoreChanged(HealthScoreChanged $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $labels = ['connection' => $event->connection, 'queue' => $event->queue];
+
+        $telemetry
+            ->gauge('queue_metrics.queue.health_score', description: 'Queue health score (0-100)', unit: '1')
+            ->set($event->currentScore, $labels);
+
+        $telemetry
+            ->counter('queue_metrics.health.changes', 'Queue health score changes by severity')
+            ->inc(1, [...$labels, 'severity' => $event->getSeverity()]);
+
+        if (in_array($event->getSeverity(), ['warning', 'critical'], true)) {
+            $telemetry->event('queue_metrics.health.changed', [
+                ...$labels,
+                'score' => $event->currentScore,
+                'previous_score' => $event->previousScore,
+                'status' => $event->status,
+                'severity' => $event->getSeverity(),
+            ]);
+
+            $telemetry->flush();
+        }
+    }
+
+    public function handleQueueDepthThresholdExceeded(QueueDepthThresholdExceeded $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $labels = ['connection' => $event->depth->connection, 'queue' => $event->depth->queue];
+
+        $telemetry
+            ->counter('queue_metrics.queue.depth_threshold.exceeded', 'Times a queue exceeded its depth threshold')
+            ->inc(1, $labels);
+
+        $telemetry->event('queue_metrics.queue.depth_threshold.exceeded', [
+            ...$labels,
+            'depth' => $event->depth->totalJobs(),
+            'threshold' => $event->threshold,
+            'percentage_over' => $event->percentageOver,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleJobMetricsDebounced(JobMetricsDebounced $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $this->telemetry()
+            ->counter('queue_metrics.jobs.debounced', 'Jobs superseded by debouncing')
+            ->inc(1, ['job.name' => $event->jobClass, 'queue' => $event->queue]);
+    }
+
+    public function handleWorkerEfficiencyChanged(WorkerEfficiencyChanged $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+
+        $telemetry
+            ->gauge('queue_metrics.workers.efficiency', description: 'Worker fleet efficiency', unit: '%')
+            ->set($event->currentEfficiency);
+
+        $recommendation = $event->getScalingRecommendation();
+
+        if ($recommendation !== 'maintain') {
+            $telemetry->event('queue_metrics.workers.scaling_recommendation', [
+                'recommendation' => $recommendation,
+                'efficiency' => $event->currentEfficiency,
+                'previous_efficiency' => $event->previousEfficiency,
+                'active_workers' => $event->activeWorkers,
+                'idle_workers' => $event->idleWorkers,
+            ]);
+
+            $telemetry->flush();
+        }
+    }
+
+    public function handleBaselineRecalculated(BaselineRecalculated $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $this->telemetry()
+            ->counter('queue_metrics.baseline.recalculations', 'Baseline recalculations by significance')
+            ->inc(1, [
+                'connection' => $event->connection,
+                'queue' => $event->queue,
+                'significant' => $event->significantChange ? 'true' : 'false',
+            ]);
+    }
+
+    private function enabled(): bool
+    {
+        return (bool) config('queue-metrics.telemetry.events', true);
+    }
+
+    private function telemetry(): TelemetryManager
+    {
+        return $this->container->make(TelemetryManager::class);
+    }
+}

--- a/src/Telemetry/TelemetryEventSubscriber.php
+++ b/src/Telemetry/TelemetryEventSubscriber.php
@@ -44,28 +44,30 @@ final readonly class TelemetryEventSubscriber
             return;
         }
 
-        $telemetry = $this->telemetry();
-        $labels = ['connection' => $event->connection, 'queue' => $event->queue];
+        $this->guard(function () use ($event): void {
+            $telemetry = $this->telemetry();
+            $labels = ['connection' => $event->connection, 'queue' => $event->queue];
 
-        $telemetry
-            ->gauge('queue_metrics.queue.health_score', description: 'Queue health score (0-100)', unit: '1')
-            ->set($event->currentScore, $labels);
+            $telemetry
+                ->gauge('queue_metrics.queue.health_score', description: 'Queue health score (0-100)', unit: '1')
+                ->set($event->currentScore, $labels);
 
-        $telemetry
-            ->counter('queue_metrics.health.changes', 'Queue health score changes by severity')
-            ->inc(1, [...$labels, 'severity' => $event->getSeverity()]);
+            $telemetry
+                ->counter('queue_metrics.health.changes', 'Queue health score changes by severity')
+                ->inc(1, [...$labels, 'severity' => $event->getSeverity()]);
 
-        if (in_array($event->getSeverity(), ['warning', 'critical'], true)) {
-            $telemetry->event('queue_metrics.health.changed', [
-                ...$labels,
-                'score' => $event->currentScore,
-                'previous_score' => $event->previousScore,
-                'status' => $event->status,
-                'severity' => $event->getSeverity(),
-            ]);
+            if (in_array($event->getSeverity(), ['warning', 'critical'], true)) {
+                $telemetry->event('queue_metrics.health.changed', [
+                    ...$labels,
+                    'score' => $event->currentScore,
+                    'previous_score' => $event->previousScore,
+                    'status' => $event->status,
+                    'severity' => $event->getSeverity(),
+                ]);
 
-            $telemetry->flush();
-        }
+                $telemetry->flush();
+            }
+        });
     }
 
     public function handleQueueDepthThresholdExceeded(QueueDepthThresholdExceeded $event): void
@@ -74,21 +76,23 @@ final readonly class TelemetryEventSubscriber
             return;
         }
 
-        $telemetry = $this->telemetry();
-        $labels = ['connection' => $event->depth->connection, 'queue' => $event->depth->queue];
+        $this->guard(function () use ($event): void {
+            $telemetry = $this->telemetry();
+            $labels = ['connection' => $event->depth->connection, 'queue' => $event->depth->queue];
 
-        $telemetry
-            ->counter('queue_metrics.queue.depth_threshold.exceeded', 'Times a queue exceeded its depth threshold')
-            ->inc(1, $labels);
+            $telemetry
+                ->counter('queue_metrics.queue.depth_threshold.exceeded', 'Times a queue exceeded its depth threshold')
+                ->inc(1, $labels);
 
-        $telemetry->event('queue_metrics.queue.depth_threshold.exceeded', [
-            ...$labels,
-            'depth' => $event->depth->totalJobs(),
-            'threshold' => $event->threshold,
-            'percentage_over' => $event->percentageOver,
-        ]);
+            $telemetry->event('queue_metrics.queue.depth_threshold.exceeded', [
+                ...$labels,
+                'depth' => $event->depth->totalJobs(),
+                'threshold' => $event->threshold,
+                'percentage_over' => $event->percentageOver,
+            ]);
 
-        $telemetry->flush();
+            $telemetry->flush();
+        });
     }
 
     public function handleJobMetricsDebounced(JobMetricsDebounced $event): void
@@ -97,9 +101,11 @@ final readonly class TelemetryEventSubscriber
             return;
         }
 
-        $this->telemetry()
-            ->counter('queue_metrics.jobs.debounced', 'Jobs superseded by debouncing')
-            ->inc(1, ['job.name' => $event->jobClass, 'queue' => $event->queue]);
+        $this->guard(function () use ($event): void {
+            $this->telemetry()
+                ->counter('queue_metrics.jobs.debounced', 'Jobs superseded by debouncing')
+                ->inc(1, ['job.name' => $event->jobClass, 'queue' => $event->queue]);
+        });
     }
 
     public function handleWorkerEfficiencyChanged(WorkerEfficiencyChanged $event): void
@@ -108,25 +114,27 @@ final readonly class TelemetryEventSubscriber
             return;
         }
 
-        $telemetry = $this->telemetry();
+        $this->guard(function () use ($event): void {
+            $telemetry = $this->telemetry();
 
-        $telemetry
-            ->gauge('queue_metrics.workers.efficiency', description: 'Worker fleet efficiency', unit: '%')
-            ->set($event->currentEfficiency);
+            $telemetry
+                ->gauge('queue_metrics.workers.efficiency', description: 'Worker fleet efficiency', unit: '%')
+                ->set($event->currentEfficiency);
 
-        $recommendation = $event->getScalingRecommendation();
+            $recommendation = $event->getScalingRecommendation();
 
-        if ($recommendation !== 'maintain') {
-            $telemetry->event('queue_metrics.workers.scaling_recommendation', [
-                'recommendation' => $recommendation,
-                'efficiency' => $event->currentEfficiency,
-                'previous_efficiency' => $event->previousEfficiency,
-                'active_workers' => $event->activeWorkers,
-                'idle_workers' => $event->idleWorkers,
-            ]);
+            if ($recommendation !== 'maintain') {
+                $telemetry->event('queue_metrics.workers.scaling_recommendation', [
+                    'recommendation' => $recommendation,
+                    'efficiency' => $event->currentEfficiency,
+                    'previous_efficiency' => $event->previousEfficiency,
+                    'active_workers' => $event->activeWorkers,
+                    'idle_workers' => $event->idleWorkers,
+                ]);
 
-            $telemetry->flush();
-        }
+                $telemetry->flush();
+            }
+        });
     }
 
     public function handleBaselineRecalculated(BaselineRecalculated $event): void
@@ -135,18 +143,35 @@ final readonly class TelemetryEventSubscriber
             return;
         }
 
-        $this->telemetry()
-            ->counter('queue_metrics.baseline.recalculations', 'Baseline recalculations by significance')
-            ->inc(1, [
-                'connection' => $event->connection,
-                'queue' => $event->queue,
-                'significant' => $event->significantChange ? 'true' : 'false',
-            ]);
+        $this->guard(function () use ($event): void {
+            $this->telemetry()
+                ->counter('queue_metrics.baseline.recalculations', 'Baseline recalculations by significance')
+                ->inc(1, [
+                    'connection' => $event->connection,
+                    'queue' => $event->queue,
+                    'significant' => $event->significantChange ? 'true' : 'false',
+                ]);
+        });
     }
 
     private function enabled(): bool
     {
         return (bool) config('queue-metrics.telemetry.events', true);
+    }
+
+    /**
+     * Telemetry must never break the process that happens to dispatch a
+     * domain event (queue workers, scheduled commands). Failures are
+     * reported and swallowed — the same contract as telemetry's own
+     * FailSafe, without coupling to its internals.
+     */
+    private function guard(callable $callback): void
+    {
+        try {
+            $callback();
+        } catch (\Throwable $exception) {
+            report($exception);
+        }
     }
 
     private function telemetry(): TelemetryManager

--- a/tests/Feature/Console/DoctorCommandTest.php
+++ b/tests/Feature/Console/DoctorCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\Telemetry\TelemetryServiceProvider;
+
+beforeEach(function () {
+    config([
+        'queue-metrics.enabled' => true,
+        'queue-metrics.prometheus.enabled' => true,
+        'queue-metrics.telemetry.enabled' => true,
+    ]);
+});
+
+function registerTelemetry(): void
+{
+    app()->register(TelemetryServiceProvider::class);
+
+    config([
+        'telemetry.enabled' => true,
+        'telemetry.store' => 'array',
+    ]);
+}
+
+it('warns when metrics are exposed via both prometheus and the telemetry integration', function () {
+    registerTelemetry();
+
+    $this->artisan('queue-metrics:doctor')
+        ->expectsOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('does not warn about double exposure when the telemetry integration is disabled', function () {
+    registerTelemetry();
+    config(['queue-metrics.telemetry.enabled' => false]);
+
+    $this->artisan('queue-metrics:doctor')
+        ->doesntExpectOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('does not warn about double exposure when prometheus is disabled', function () {
+    registerTelemetry();
+    config(['queue-metrics.prometheus.enabled' => false]);
+
+    $this->artisan('queue-metrics:doctor')
+        ->doesntExpectOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('does not warn about double exposure when the host telemetry package is disabled', function () {
+    registerTelemetry();
+    config(['telemetry.enabled' => false]);
+
+    $this->artisan('queue-metrics:doctor')
+        ->doesntExpectOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('does not warn when the telemetry manager is not bound', function () {
+    $this->artisan('queue-metrics:doctor')
+        ->doesntExpectOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('does not warn when every telemetry publish toggle is off', function () {
+    registerTelemetry();
+    config([
+        'queue-metrics.telemetry.gauges.queues' => false,
+        'queue-metrics.telemetry.gauges.workers' => false,
+        'queue-metrics.telemetry.gauges.baselines' => false,
+        'queue-metrics.telemetry.events' => false,
+    ]);
+
+    $this->artisan('queue-metrics:doctor')
+        ->doesntExpectOutputToContain('exposed twice')
+        ->assertSuccessful();
+})->group('functional');
+
+it('reports core configuration state', function () {
+    config(['queue-metrics.storage.driver' => 'database']);
+
+    $this->artisan('queue-metrics:doctor')
+        ->expectsOutputToContain('database')
+        ->assertSuccessful();
+})->group('functional');

--- a/tests/Feature/Console/DoctorCommandTest.php
+++ b/tests/Feature/Console/DoctorCommandTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Cbox\Telemetry\TelemetryServiceProvider;
+use PHPUnit\Framework\Assert;
 
 beforeEach(function () {
     config([
@@ -14,6 +15,10 @@ beforeEach(function () {
 
 function registerTelemetry(): void
 {
+    if (! class_exists(TelemetryServiceProvider::class)) {
+        Assert::markTestSkipped('cboxdk/laravel-telemetry is not installed (Laravel 12+ only)');
+    }
+
     app()->register(TelemetryServiceProvider::class);
 
     config([

--- a/tests/Feature/Telemetry/QueueMetricsTelemetryProviderTest.php
+++ b/tests/Feature/Telemetry/QueueMetricsTelemetryProviderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueMetrics\Telemetry\QueueMetricsTelemetryProvider;
+use Cbox\Telemetry\Facades\Telemetry;
+
+beforeEach(function () {
+    config(['queue-metrics.telemetry.enabled' => true]);
+
+    $this->fake = Telemetry::fake();
+});
+
+function bindTelemetrySnapshot(
+    array $queues = [],
+    array $workers = [],
+    array $baselines = [],
+): void {
+    $snapshot = Mockery::mock(ProvidesTelemetrySnapshot::class);
+    $snapshot->shouldReceive('snapshot')->andReturn([
+        'queues' => $queues,
+        'workers' => $workers === [] ? [
+            'count' => ['total' => 0, 'active' => 0, 'idle' => 0],
+            'utilization' => ['current_busy_percent' => 0.0, 'lifetime_busy_percent' => 0.0],
+        ] : $workers,
+        'baselines' => $baselines,
+    ]);
+
+    app()->instance(ProvidesTelemetrySnapshot::class, $snapshot);
+}
+
+function exampleQueue(): array
+{
+    return [
+        [
+            'connection' => 'redis',
+            'queue' => 'default',
+            'depth' => [
+                'total' => 15,
+                'pending' => 10,
+                'scheduled' => 3,
+                'reserved' => 2,
+                'oldest_job_age_seconds' => 42,
+            ],
+            'performance_60s' => [
+                'throughput_per_minute' => 12.5,
+                'avg_duration_ms' => 250.0,
+            ],
+            'lifetime' => [
+                'failure_rate_percent' => 1.5,
+            ],
+            'workers' => [
+                'active_count' => 4,
+                'current_busy_percent' => 50.0,
+                'lifetime_busy_percent' => 75.0,
+            ],
+        ],
+    ];
+}
+
+it('publishes queue depth gauges by state', function () {
+    bindTelemetrySnapshot(queues: exampleQueue());
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    expect($this->fake->gaugeValue('queue_metrics.queue.depth', [...$labels, 'state' => 'pending']))->toBe(10.0)
+        ->and($this->fake->gaugeValue('queue_metrics.queue.depth', [...$labels, 'state' => 'scheduled']))->toBe(3.0)
+        ->and($this->fake->gaugeValue('queue_metrics.queue.depth', [...$labels, 'state' => 'reserved']))->toBe(2.0);
+})->group('functional');
+
+it('publishes queue backlog, throughput, failure rate and active workers gauges', function () {
+    bindTelemetrySnapshot(queues: exampleQueue());
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    expect($this->fake->gaugeValue('queue_metrics.queue.oldest_job.age', $labels))->toBe(42.0)
+        ->and($this->fake->gaugeValue('queue_metrics.queue.throughput', $labels))->toBe(12.5)
+        ->and($this->fake->gaugeValue('queue_metrics.queue.failure_rate', $labels))->toBe(1.5)
+        ->and($this->fake->gaugeValue('queue_metrics.queue.active_workers', $labels))->toBe(4.0);
+})->group('functional');
+
+it('publishes worker summary gauges', function () {
+    bindTelemetrySnapshot(workers: [
+        'count' => ['total' => 5, 'active' => 3, 'idle' => 2],
+        'utilization' => ['current_busy_percent' => 60.0, 'lifetime_busy_percent' => 80.0],
+    ]);
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    expect($this->fake->gaugeValue('queue_metrics.workers.count', ['state' => 'busy']))->toBe(3.0)
+        ->and($this->fake->gaugeValue('queue_metrics.workers.count', ['state' => 'idle']))->toBe(2.0)
+        ->and($this->fake->gaugeValue('queue_metrics.workers.utilization', ['window' => 'current']))->toBe(60.0)
+        ->and($this->fake->gaugeValue('queue_metrics.workers.utilization', ['window' => 'lifetime']))->toBe(80.0);
+})->group('functional');
+
+it('publishes baseline gauges per queue and job class', function () {
+    bindTelemetrySnapshot(queues: exampleQueue(), baselines: [
+        [
+            'connection' => 'redis',
+            'queue' => 'default',
+            'job_class' => 'App\\Jobs\\SendEmail',
+            'cpu_percent_per_job' => 12.0,
+            'memory_mb_per_job' => 64.0,
+            'avg_duration_ms' => 250.0,
+            'sample_count' => 100,
+            'confidence_score' => 0.9,
+        ],
+    ]);
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default', 'job.name' => 'App\\Jobs\\SendEmail'];
+
+    expect($this->fake->gaugeValue('queue_metrics.baseline.duration', $labels))->toBe(250.0)
+        ->and($this->fake->gaugeValue('queue_metrics.baseline.memory', $labels))->toBe(64.0)
+        ->and($this->fake->gaugeValue('queue_metrics.baseline.cpu', $labels))->toBe(12.0)
+        ->and($this->fake->gaugeValue('queue_metrics.baseline.confidence', $labels))->toBe(0.9);
+})->group('functional');
+
+it('does not register queue gauges when the queues toggle is disabled', function () {
+    config(['queue-metrics.telemetry.gauges.queues' => false]);
+
+    bindTelemetrySnapshot(queues: exampleQueue());
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    $names = array_map(fn ($family) => $family->name(), $this->fake->collect());
+
+    expect($names)->not->toContain('queue_metrics.queue.depth')
+        ->and($names)->toContain('queue_metrics.workers.count');
+})->group('functional');
+
+it('does not register baseline gauges when the baselines toggle is disabled', function () {
+    config(['queue-metrics.telemetry.gauges.baselines' => false]);
+
+    bindTelemetrySnapshot(queues: exampleQueue());
+
+    $this->fake->provider(new QueueMetricsTelemetryProvider(app()));
+
+    $names = array_map(fn ($family) => $family->name(), $this->fake->collect());
+
+    expect($names)->not->toContain('queue_metrics.baseline.duration');
+})->group('functional');
+
+it('identifies itself as the cbox.queue-metrics provider', function () {
+    expect((new QueueMetricsTelemetryProvider(app()))->name())->toBe('cbox.queue-metrics');
+})->group('functional');

--- a/tests/Feature/Telemetry/QueueMetricsTelemetryProviderTest.php
+++ b/tests/Feature/Telemetry/QueueMetricsTelemetryProviderTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 use Cbox\LaravelQueueMetrics\Telemetry\Contracts\ProvidesTelemetrySnapshot;
 use Cbox\LaravelQueueMetrics\Telemetry\QueueMetricsTelemetryProvider;
 use Cbox\Telemetry\Facades\Telemetry;
+use Cbox\Telemetry\TelemetryManager;
 
 beforeEach(function () {
+    if (! class_exists(TelemetryManager::class)) {
+        $this->markTestSkipped('cboxdk/laravel-telemetry is not installed (Laravel 12+ only)');
+    }
+
     config(['queue-metrics.telemetry.enabled' => true]);
 
     $this->fake = Telemetry::fake();

--- a/tests/Feature/Telemetry/QueueMetricsTelemetrySnapshotTest.php
+++ b/tests/Feature/Telemetry/QueueMetricsTelemetrySnapshotTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\BaselineRepository;
+use Cbox\LaravelQueueMetrics\Services\QueueMetricsQueryService;
+use Cbox\LaravelQueueMetrics\Services\WorkerMetricsQueryService;
+use Cbox\LaravelQueueMetrics\Telemetry\QueueMetricsTelemetrySnapshot;
+
+function bindCountingSnapshotServices(): object
+{
+    $queueService = new class
+    {
+        public int $calls = 0;
+
+        /**
+         * @return array<string, array<string, mixed>>
+         */
+        public function getAllQueuesWithMetrics(): array
+        {
+            $this->calls++;
+
+            return [];
+        }
+    };
+
+    $workerService = new class
+    {
+        /**
+         * @return array<string, mixed>
+         */
+        public function getWorkersSummary(): array
+        {
+            return [];
+        }
+    };
+
+    app()->instance(QueueMetricsQueryService::class, $queueService);
+    app()->instance(WorkerMetricsQueryService::class, $workerService);
+    app()->instance(BaselineRepository::class, Mockery::mock(BaselineRepository::class));
+
+    return $queueService;
+}
+
+it('builds the snapshot only once per scrape even with the shared cache disabled', function () {
+    config(['queue-metrics.telemetry.cache_ttl' => 0]);
+
+    $queueService = bindCountingSnapshotServices();
+
+    $snapshot = new QueueMetricsTelemetrySnapshot(app());
+
+    $snapshot->snapshot();
+    $snapshot->snapshot();
+    $snapshot->snapshot();
+
+    expect($queueService->calls)->toBe(1);
+})->group('functional');

--- a/tests/Feature/Telemetry/TelemetryBootWiringTest.php
+++ b/tests/Feature/Telemetry/TelemetryBootWiringTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueMetrics\Events\BaselineRecalculated;
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Cbox\LaravelQueueMetrics\Events\QueueDepthThresholdExceeded;
+use Cbox\LaravelQueueMetrics\Events\WorkerEfficiencyChanged;
+use Cbox\LaravelQueueMetrics\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueMetrics\Tests\TestCase;
+use Cbox\Telemetry\Facades\Telemetry;
+use Cbox\Telemetry\TelemetryManager;
+use Cbox\Telemetry\TelemetryServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+
+final class TelemetryBootWiringTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];
+    }
+
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('queue-metrics.enabled', true);
+        $app['config']->set('queue-metrics.storage.driver', 'database');
+        $app['config']->set('telemetry.enabled', true);
+        $app['config']->set('telemetry.store', 'array');
+    }
+
+    public function test_it_subscribes_to_package_events_at_boot(): void
+    {
+        foreach ([
+            HealthScoreChanged::class,
+            QueueDepthThresholdExceeded::class,
+            JobMetricsDebounced::class,
+            WorkerEfficiencyChanged::class,
+            BaselineRecalculated::class,
+        ] as $event) {
+            $this->assertTrue(Event::hasListeners($event), "No listener registered for {$event}");
+        }
+    }
+
+    public function test_it_registers_the_telemetry_provider_with_the_manager(): void
+    {
+        $snapshot = Mockery::mock(ProvidesTelemetrySnapshot::class);
+        $snapshot->shouldReceive('snapshot')->andReturn([
+            'queues' => [],
+            'workers' => [
+                'count' => ['total' => 1, 'active' => 1, 'idle' => 0],
+                'utilization' => ['current_busy_percent' => 100.0, 'lifetime_busy_percent' => 50.0],
+            ],
+            'baselines' => [],
+        ]);
+
+        $this->app->instance(ProvidesTelemetrySnapshot::class, $snapshot);
+
+        $families = $this->app->make(TelemetryManager::class)->collect();
+        $names = array_map(fn ($family) => $family->name(), $families);
+
+        $this->assertContains('queue_metrics.workers.count', $names);
+    }
+
+    public function test_it_binds_a_default_snapshot_implementation(): void
+    {
+        $this->assertTrue($this->app->bound(ProvidesTelemetrySnapshot::class));
+    }
+
+    public function test_dispatched_domain_events_reach_telemetry(): void
+    {
+        $fake = Telemetry::fake();
+
+        event(new HealthScoreChanged('redis', 'default', 45.0, 80.0, 'degraded'));
+
+        $fake->assertCounterIncremented('queue_metrics.health.changes', [
+            'connection' => 'redis',
+            'queue' => 'default',
+            'severity' => 'critical',
+        ]);
+    }
+}

--- a/tests/Feature/Telemetry/TelemetryBootWiringTest.php
+++ b/tests/Feature/Telemetry/TelemetryBootWiringTest.php
@@ -19,6 +19,15 @@ use Mockery;
 
 final class TelemetryBootWiringTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('cboxdk/laravel-telemetry is not installed (Laravel 12+ only)');
+        }
+
+        parent::setUp();
+    }
+
     protected function getPackageProviders($app)
     {
         return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];

--- a/tests/Feature/Telemetry/TelemetryDisabledTest.php
+++ b/tests/Feature/Telemetry/TelemetryDisabledTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Tests\TestCase;
+use Cbox\Telemetry\TelemetryServiceProvider;
+use Illuminate\Support\Facades\Event;
+
+final class TelemetryDisabledTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];
+    }
+
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('queue-metrics.enabled', true);
+        $app['config']->set('queue-metrics.storage.driver', 'database');
+        $app['config']->set('queue-metrics.telemetry.enabled', false);
+        $app['config']->set('telemetry.enabled', true);
+        $app['config']->set('telemetry.store', 'array');
+    }
+
+    public function test_it_does_not_subscribe_to_package_events_when_disabled(): void
+    {
+        $this->assertFalse(Event::hasListeners(HealthScoreChanged::class));
+    }
+}

--- a/tests/Feature/Telemetry/TelemetryDisabledTest.php
+++ b/tests/Feature/Telemetry/TelemetryDisabledTest.php
@@ -6,11 +6,21 @@ namespace Cbox\LaravelQueueMetrics\Tests\Feature\Telemetry;
 
 use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
 use Cbox\LaravelQueueMetrics\Tests\TestCase;
+use Cbox\Telemetry\TelemetryManager;
 use Cbox\Telemetry\TelemetryServiceProvider;
 use Illuminate\Support\Facades\Event;
 
 final class TelemetryDisabledTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('cboxdk/laravel-telemetry is not installed (Laravel 12+ only)');
+        }
+
+        parent::setUp();
+    }
+
     protected function getPackageProviders($app)
     {
         return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];

--- a/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
+++ b/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\BaselineData;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueDepthData;
+use Cbox\LaravelQueueMetrics\Events\BaselineRecalculated;
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Events\JobMetricsDebounced;
+use Cbox\LaravelQueueMetrics\Events\QueueDepthThresholdExceeded;
+use Cbox\LaravelQueueMetrics\Events\WorkerEfficiencyChanged;
+use Cbox\LaravelQueueMetrics\Telemetry\TelemetryEventSubscriber;
+use Cbox\Telemetry\Facades\Telemetry;
+
+beforeEach(function () {
+    config([
+        'queue-metrics.telemetry.enabled' => true,
+        'queue-metrics.telemetry.events' => true,
+    ]);
+
+    $this->fake = Telemetry::fake();
+    $this->subscriber = new TelemetryEventSubscriber(app());
+});
+
+it('records health score changes as a gauge and severity counter', function () {
+    $this->subscriber->handleHealthScoreChanged(new HealthScoreChanged(
+        connection: 'redis',
+        queue: 'default',
+        currentScore: 45.0,
+        previousScore: 80.0,
+        status: 'degraded',
+    ));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    expect($this->fake->gaugeValue('queue_metrics.queue.health_score', $labels))->toBe(45.0);
+
+    $this->fake->assertCounterIncremented('queue_metrics.health.changes', [...$labels, 'severity' => 'critical']);
+    $this->fake->assertEventEmitted('queue_metrics.health.changed');
+})->group('functional');
+
+it('does not emit a health event for small score changes', function () {
+    $this->subscriber->handleHealthScoreChanged(new HealthScoreChanged(
+        connection: 'redis',
+        queue: 'default',
+        currentScore: 78.0,
+        previousScore: 80.0,
+        status: 'healthy',
+    ));
+
+    $this->fake->assertEventNotEmitted('queue_metrics.health.changed');
+})->group('functional');
+
+it('records queue depth threshold breaches as a counter and event', function () {
+    $this->subscriber->handleQueueDepthThresholdExceeded(new QueueDepthThresholdExceeded(
+        depth: new QueueDepthData(
+            connection: 'redis',
+            queue: 'default',
+            pendingJobs: 1500,
+            reservedJobs: 10,
+            delayedJobs: 5,
+            oldestPendingJobAge: Carbon::now()->subMinutes(10),
+            oldestDelayedJobAge: null,
+            measuredAt: Carbon::now(),
+        ),
+        threshold: 1000,
+        percentageOver: 50.0,
+    ));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    $this->fake->assertCounterIncremented('queue_metrics.queue.depth_threshold.exceeded', $labels);
+    $this->fake->assertEventEmitted('queue_metrics.queue.depth_threshold.exceeded');
+})->group('functional');
+
+it('counts debounced jobs', function () {
+    $this->subscriber->handleJobMetricsDebounced(new JobMetricsDebounced(
+        jobId: 'job-1',
+        jobClass: 'App\\Jobs\\SendEmail',
+        connection: 'redis',
+        queue: 'default',
+    ));
+
+    $this->fake->assertCounterIncremented('queue_metrics.jobs.debounced', [
+        'job.name' => 'App\\Jobs\\SendEmail',
+        'queue' => 'default',
+    ]);
+})->group('functional');
+
+it('records worker efficiency and emits scaling recommendations', function () {
+    $this->subscriber->handleWorkerEfficiencyChanged(new WorkerEfficiencyChanged(
+        currentEfficiency: 95.0,
+        previousEfficiency: 70.0,
+        changePercentage: 35.7,
+        activeWorkers: 8,
+        idleWorkers: 0,
+    ));
+
+    expect($this->fake->gaugeValue('queue_metrics.workers.efficiency'))->toBe(95.0);
+
+    $this->fake->assertEventEmitted('queue_metrics.workers.scaling_recommendation', function ($event) {
+        return $event->attributes['recommendation'] === 'scale_up';
+    });
+})->group('functional');
+
+it('does not emit a scaling event when the recommendation is maintain', function () {
+    $this->subscriber->handleWorkerEfficiencyChanged(new WorkerEfficiencyChanged(
+        currentEfficiency: 70.0,
+        previousEfficiency: 72.0,
+        changePercentage: -2.8,
+        activeWorkers: 4,
+        idleWorkers: 1,
+    ));
+
+    $this->fake->assertEventNotEmitted('queue_metrics.workers.scaling_recommendation');
+})->group('functional');
+
+it('counts baseline recalculations with significance', function () {
+    $this->subscriber->handleBaselineRecalculated(new BaselineRecalculated(
+        connection: 'redis',
+        queue: 'default',
+        baseline: new BaselineData(
+            connection: 'redis',
+            queue: 'default',
+            jobClass: '',
+            cpuPercentPerJob: 10.0,
+            memoryMbPerJob: 32.0,
+            avgDurationMs: 100.0,
+            sampleCount: 50,
+            confidenceScore: 0.8,
+            calculatedAt: Carbon::now(),
+        ),
+        significantChange: true,
+    ));
+
+    $this->fake->assertCounterIncremented('queue_metrics.baseline.recalculations', [
+        'connection' => 'redis',
+        'queue' => 'default',
+        'significant' => 'true',
+    ]);
+})->group('functional');
+
+it('records nothing when the events toggle is disabled', function () {
+    config(['queue-metrics.telemetry.events' => false]);
+
+    $this->subscriber->handleHealthScoreChanged(new HealthScoreChanged(
+        connection: 'redis',
+        queue: 'default',
+        currentScore: 45.0,
+        previousScore: 80.0,
+        status: 'degraded',
+    ));
+
+    $this->fake->assertCounterNotIncremented('queue_metrics.health.changes');
+})->group('functional');
+
+it('maps package events to handler methods', function () {
+    $subscriptions = $this->subscriber->subscribe();
+
+    expect($subscriptions)->toHaveKeys([
+        HealthScoreChanged::class,
+        QueueDepthThresholdExceeded::class,
+        JobMetricsDebounced::class,
+        WorkerEfficiencyChanged::class,
+        BaselineRecalculated::class,
+    ]);
+})->group('functional');

--- a/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
+++ b/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
@@ -15,6 +15,10 @@ use Cbox\Telemetry\Facades\Telemetry;
 use Cbox\Telemetry\TelemetryManager;
 
 beforeEach(function () {
+    if (! class_exists(TelemetryManager::class)) {
+        $this->markTestSkipped('cboxdk/laravel-telemetry is not installed (Laravel 12+ only)');
+    }
+
     config([
         'queue-metrics.telemetry.enabled' => true,
         'queue-metrics.telemetry.events' => true,

--- a/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
+++ b/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
@@ -12,6 +12,7 @@ use Cbox\LaravelQueueMetrics\Events\QueueDepthThresholdExceeded;
 use Cbox\LaravelQueueMetrics\Events\WorkerEfficiencyChanged;
 use Cbox\LaravelQueueMetrics\Telemetry\TelemetryEventSubscriber;
 use Cbox\Telemetry\Facades\Telemetry;
+use Cbox\Telemetry\TelemetryManager;
 
 beforeEach(function () {
     config([
@@ -153,6 +154,31 @@ it('records nothing when the events toggle is disabled', function () {
     ));
 
     $this->fake->assertCounterNotIncremented('queue_metrics.health.changes');
+})->group('functional');
+
+it('never lets telemetry failures propagate into the dispatching process', function () {
+    $throwing = Mockery::mock(TelemetryManager::class);
+    $throwing->shouldReceive('gauge', 'counter', 'event', 'flush')
+        ->andThrow(new RuntimeException('telemetry backend down'));
+
+    app()->instance(TelemetryManager::class, $throwing);
+
+    $this->subscriber->handleHealthScoreChanged(new HealthScoreChanged(
+        connection: 'redis',
+        queue: 'default',
+        currentScore: 45.0,
+        previousScore: 80.0,
+        status: 'degraded',
+    ));
+
+    $this->subscriber->handleJobMetricsDebounced(new JobMetricsDebounced(
+        jobId: 'job-1',
+        jobClass: 'App\\Jobs\\SendEmail',
+        connection: 'redis',
+        queue: 'default',
+    ));
+
+    expect(true)->toBeTrue();
 })->group('functional');
 
 it('maps package events to handler methods', function () {

--- a/tests/Feature/Telemetry/TelemetryNotBoundTest.php
+++ b/tests/Feature/Telemetry/TelemetryNotBoundTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMetrics\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
+use Cbox\LaravelQueueMetrics\Tests\TestCase;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * The telemetry classes are autoloadable in this test suite, but the
+ * TelemetryServiceProvider is deliberately NOT registered — the state a
+ * host app is in with `dont-discover` or a stale package cache. The
+ * integration must stay fully inert instead of subscribing listeners
+ * that would throw a BindingResolutionException on the first event.
+ */
+final class TelemetryNotBoundTest extends TestCase
+{
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('queue-metrics.enabled', true);
+        $app['config']->set('queue-metrics.storage.driver', 'database');
+    }
+
+    public function test_it_does_not_subscribe_when_the_telemetry_manager_is_not_bound(): void
+    {
+        $this->assertFalse(Event::hasListeners(HealthScoreChanged::class));
+    }
+
+    public function test_dispatching_a_domain_event_does_not_throw(): void
+    {
+        event(new HealthScoreChanged('redis', 'default', 45.0, 80.0, 'degraded'));
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary

When [cboxdk/laravel-telemetry](https://github.com/cboxdk/laravel-telemetry) is installed, queue-metrics now publishes the state telemetry cannot see on its own — batteries included: on by default, fully inert when the package is absent.

**What gets published** (full table with units/labels in the README):
- **Observable gauges** (scrape-time, from a cached snapshot): queue depth by state, oldest-job age, throughput, failure rate, active workers, worker counts/utilization, baselines (duration/memory/CPU/confidence)
- **Push signals** (from package domain events): health score gauge + severity counter, depth-threshold-exceeded counter, debounced-jobs counter, worker efficiency gauge, baseline recalculation counter — plus structured OTLP events for severe health changes, threshold breaches and scaling recommendations

Per-job durations/memory/outcomes are deliberately **not** re-exported — laravel-telemetry's own `QueueInstrumentation` already covers those.

## Design

- `require-dev` + `suggest` only — never a hard dependency. Registration is guarded by `class_exists` + container `bound()` + `queue-metrics.telemetry.enabled` (default true)
- `ProvidesTelemetrySnapshot` contract seams the gauge callbacks off the final query services (testable, swappable) with a short shared cache so concurrent scrapes don't all scan the store
- `TelemetryManager` is resolved from the container per event so `Telemetry::fake()` works in consuming apps' tests

## Crash safety (three layers)

1. Boot: class-autoloadable-but-provider-unregistered (`dont-discover`, stale package cache) leaves the integration fully inert instead of subscribing listeners that would throw `BindingResolutionException`
2. Pull: telemetry's own `FailSafe` guards each gauge callback — a failing callback drops only its own family
3. Push: every subscriber handler is wrapped in a report-and-swallow guard, so a throwing telemetry backend or alpha API drift can never break the queue worker / scheduled command dispatching the event

## New `queue-metrics:doctor` command

Reports configuration state and warns when the built-in Prometheus exporter and the telemetry integration are both actively publishing — the same queue state exposed twice. Recommends which env var to disable.

## Config

New `queue-metrics.telemetry` block: master toggle (`QUEUE_METRICS_TELEMETRY_ENABLED`), snapshot `cache_ttl`, per-gauge-group toggles (`queues`/`workers`/`baselines`) and an `events` toggle.

## Testing

- 32 new tests (TDD): provider gauges + toggles, subscriber handlers + failure guard, boot wiring incl. end-to-end event dispatch into `TelemetryFake`, not-bound inertness, disabled paths, doctor warning matrix, snapshot per-scrape memoization
- Full suite: 396 passed / 15 skipped (pre-existing Redis-gated skips). Pint clean; PHPStan shows only the 3 pre-existing errors also present on main

## Note

`cboxdk/laravel-telemetry` is pinned `^0.2.0` in require-dev — the first tag without a pre-release suffix, whose public API is declared stable-enough per SemVer 0.x (breaking changes bump the minor). v0.2.0 also adds a re-entrancy latch in telemetry's FailSafe, so failures our push-side guard hands to `report()` can no longer recurse. All 32 integration tests pass against v0.2.0 unchanged.
