### PR TITLE
Add Redis Cluster support (cluster `SCAN`, hash-tag-aware depth keys, cluster-safe writes)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - '**.php'
-      - '.github/workflows/run-tests.yml'
-      - 'phpunit.xml.dist'
-      - 'composer.json'
-      - 'composer.lock'
+      - "**.php"
+      - ".github/workflows/run-tests.yml"
+      - "phpunit.xml.dist"
+      - "composer.json"
+      - "composer.lock"
   pull_request:
     paths:
-      - '**.php'
-      - '.github/workflows/run-tests.yml'
-      - 'phpunit.xml.dist'
-      - 'composer.json'
-      - 'composer.lock'
+      - "**.php"
+      - ".github/workflows/run-tests.yml"
+      - "phpunit.xml.dist"
+      - "composer.json"
+      - "composer.lock"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,15 +30,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*, 11.*]
+        laravel: [13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 13.*
             testbench: ^11.0
-          - laravel: 12.*
-            testbench: ^10.6
-          - laravel: 11.*
-            testbench: ^9.14
         exclude:
           - php: 8.5
             stability: prefer-lowest
@@ -65,9 +61,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.laravel }}" = "11.*" ]; then
-            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
-          fi
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
@@ -89,15 +82,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*, 11.*]
+        laravel: [13.*]
         stability: [prefer-stable]
         include:
           - laravel: 13.*
             testbench: ^11.0
-          - laravel: 12.*
-            testbench: ^10.6
-          - laravel: 11.*
-            testbench: ^9.14
         exclude:
           - php: 8.3
             laravel: 13.*
@@ -133,9 +122,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.laravel }}" = "11.*" ]; then
-            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
-          fi
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
@@ -179,15 +165,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Cover both the reflection depth path (L11, no native queue size methods) and the
-        # native path (L13), on a single PHP version to keep the cluster job lean.
+        # Laravel's RedisQueue only hash-tags queue keys on 13.x, so a cluster is only
+        # driveable there; earlier versions cannot push to a cluster at all.
         include:
           - php: 8.4
             laravel: 13.*
             testbench: ^11.0
-          - php: 8.4
-            laravel: 11.*
-            testbench: ^9.14
 
     name: Redis Cluster - P${{ matrix.php }} - L${{ matrix.laravel }}
 
@@ -209,9 +192,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.laravel }}" = "11.*" ]; then
-            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
-          fi
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -172,3 +172,70 @@ jobs:
           REDIS_HOST: 127.0.0.1
           REDIS_PORT: 6379
           REDIS_AVAILABLE: true
+
+  test-with-redis-cluster:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: true
+      matrix:
+        # Cover both the reflection depth path (L11, no native queue size methods) and the
+        # native path (L13), on a single PHP version to keep the cluster job lean.
+        include:
+          - php: 8.4
+            laravel: 13.*
+            testbench: ^11.0
+          - php: 8.4
+            laravel: 11.*
+            testbench: ^9.14
+
+    name: Redis Cluster - P${{ matrix.php }} - L${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, redis
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          if [ "${{ matrix.laravel }}" = "11.*" ]; then
+            composer remove cboxdk/laravel-telemetry --dev --no-interaction --no-update
+          fi
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction
+
+      - name: List Installed Dependencies
+        run: composer show -D
+
+      - name: Create Redis Cluster
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --fix-missing redis-server
+          sudo service redis-server stop
+          redis-server --daemonize yes --port 7000 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7000.conf
+          redis-server --daemonize yes --port 7001 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7001.conf
+          redis-server --daemonize yes --port 7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
+          redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0 --cluster-yes
+
+      - name: Check Redis Cluster is ready
+        run: |
+          for port in 7000 7001 7002; do
+            redis-cli -c -h 127.0.0.1 -p "$port" cluster info | grep "cluster_state:ok"
+          done
+
+      - name: Execute cluster integration tests
+        run: vendor/bin/pest --ci --group=redis
+        env:
+          REDIS_CLUSTER_HOSTS_AND_PORTS: 127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002
+          REDIS_AVAILABLE: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,32 @@
 
 All notable changes to `laravel-queue-metrics` will be documented in this file.
 
+## v4.0.0 - Redis Cluster support - Unreleased
+
+### Added
+
+- Redis Cluster support for the metrics store: `scanKeys()` scans every master node, queue-depth reads use the `{hash tag}` key that Laravel's `RedisQueue` writes on a cluster, and the transaction/pipeline write paths issue commands individually so they work on a slot-routed connection. The single-node connection path is unchanged.
+- Cluster + single-node Redis test coverage, including a CI job that runs the Redis suite against a real 3-master cluster.
+
+### Changed
+
+- **BREAKING:** Dropped support for Laravel 11 and 12. The package now requires Laravel 13 (`illuminate/contracts: ^13.0`), whose `RedisQueue` and `Connection` APIs are required for cluster-aware queue-depth keys.
+
 ## v3.2.1 - Documentation fixes - 2026-07-15
 
 ### Fixed
+
 - Corrected a dead link in the API endpoints guide that pointed at a non-existent `prometheus.md`; it now links to the Prometheus integration guide under `advanced-usage/`.
 
 ### Changed
+
 - Moved internal planning notes out of the published `docs/` tree and added a requirements page so the documentation renders cleanly on the site.
 - Bumped the `cboxdk/laravel-telemetry` dev requirement.
 
 ## v3.2.0 - OpenTelemetry integration via laravel-telemetry - 2026-07-06
 
 ### Added
+
 - Optional OpenTelemetry integration via `cboxdk/laravel-telemetry` (on by default when installed, `QUEUE_METRICS_TELEMETRY_ENABLED=false` to disable) — observable gauges for queue depth, oldest-job age, throughput, failure rate, active workers, worker counts/utilization and baselines, plus counters and structured OTLP events for health score changes, depth threshold breaches, debounced jobs, worker efficiency and baseline recalculations
 - `queue-metrics.telemetry` config block — master toggle, snapshot `cache_ttl`, per-gauge-group toggles and events toggle
 - `ProvidesTelemetrySnapshot` contract with cached default implementation — swap it to feed the telemetry gauges from a custom source
@@ -33,6 +47,7 @@ All notable changes to `laravel-queue-metrics` will be documented in this file.
 - `AggregatedJobMetricsData::fromArray()` static factory for DTO consistency
 
 ### Changed
+
 - `memory.avg`, `memory.peak`, `memory.p95`, `memory.p99` now report peak RSS (worker's actual memory footprint during job) instead of incremental allocation — restores correct capacity-planning semantics for consumers like queue-autoscale
 - `memoryMb` in `JobMetricsCompleted` and `JobMetricsFailed` events now carries peak RSS instead of incremental
 - Internal models (`MetricsHash`, `MetricsKey`, `MetricsSet`, `MetricsSortedSet`) and `Authorize` middleware marked `final`
@@ -41,6 +56,7 @@ All notable changes to `laravel-queue-metrics` will be documented in this file.
 - `CleanupDatabaseCommand` now selects only required columns for sorted set cleanup (reduced memory ~70%)
 
 ### Fixed
+
 - queue-autoscale capacity estimates were ~10x too low because `memory.avg` reported incremental allocation (~6 MB) instead of actual worker footprint (~50-80 MB) (#20)
 - `ProcessMetrics` tracker leak when persistence throws in `JobProcessingListener` — tracker and snapshot caches are now cleaned up in catch block
 - Negative duration values from clock skew — guarded with `max(0.0, ...)`
@@ -69,6 +85,7 @@ All notable changes to `laravel-queue-metrics` will be documented in this file.
 ### Migration Guide
 
 If you have alerts or dashboards that threshold on `memoryMb`:
+
 - Old: `memoryMb ≈ 50-200 MB` (entire worker process RSS)
 - New: `memoryMb ≈ 0-N MB` (only what the job allocated)
 - For OOM monitoring, use `WorkerHeartbeat.peakMemoryUsageMb` instead
@@ -119,6 +136,7 @@ $metrics->cpu->p95;   // 95th percentile
 $metrics->cpu->p99;   // 99th percentile
 
 ```
+
 CPU time is also available in the HTTP API via the `avg_cpu_time_ms` field on job metrics endpoints.
 
 ## v2.7.0 - Debounce metrics tracking - 2026-04-27
@@ -143,6 +161,7 @@ laravel_queue_job_debounced_total{job="App\\Jobs\\SyncData",queue="default",conn
 
 
 ```
+
 #### How It Works
 
 When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), the new `JobDebouncedListener`:
@@ -160,9 +179,9 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add `persistence.enabled` config option (`QUEUE_METRICS_PERSISTENCE` env) — when `false`, listeners still instrument jobs and fire `JobMetricsCompleted`/`JobMetricsFailed` events but skip all repository writes; scheduled tasks are not registered; no Redis or database connection is required
-* tests: Add 11 tests covering persistence-disabled behavior (events fire, no repository calls, no scheduled tasks)
-* docs: Document `persistence.enabled` in configuration reference and events docs
+- feat: Add `persistence.enabled` config option (`QUEUE_METRICS_PERSISTENCE` env) — when `false`, listeners still instrument jobs and fire `JobMetricsCompleted`/`JobMetricsFailed` events but skip all repository writes; scheduled tasks are not registered; no Redis or database connection is required
+- tests: Add 11 tests covering persistence-disabled behavior (events fire, no repository calls, no scheduled tasks)
+- docs: Document `persistence.enabled` in configuration reference and events docs
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.5.0...v2.6.0
 
@@ -170,16 +189,16 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add database storage driver as alternative to Redis — stores metrics in 4 Eloquent-backed tables (`queue_metrics_keys`, `queue_metrics_hashes`, `queue_metrics_sets`, `queue_metrics_sorted_sets`)
-* feat: Add 5 database repository implementations (`DatabaseWorkerRepository`, `DatabaseWorkerHeartbeatRepository`, `DatabaseJobMetricsRepository`, `DatabaseQueueMetricsRepository`, `DatabaseBaselineRepository`) mirroring Redis behavior
-* feat: Add `DatabaseMetricsStore` providing the same API as `RedisMetricsStore` with Eloquent
-* feat: Add `queue-metrics:cleanup-database` command for expired data removal and sorted set trimming
-* feat: Driver-based repository resolution — set `QUEUE_METRICS_STORAGE=database` to auto-bind all database repositories; explicit overrides still take precedence
-* feat: Add `max_samples_per_key` and `cleanup_chunk_size` config options
-* perf: Bulk `incrementHashFields` method reduces lock contention (4 transactions → 1 per job completion)
-* perf: Heartbeat throttling for database driver — skips writes if same state and <10s since last write (~90% reduction in heartbeat queries)
-* fix: Handle `-inf`/`+inf` in sorted set score queries for database driver
-* fix: Resolve all PHPStan errors in database driver (122 errors → 0)
+- feat: Add database storage driver as alternative to Redis — stores metrics in 4 Eloquent-backed tables (`queue_metrics_keys`, `queue_metrics_hashes`, `queue_metrics_sets`, `queue_metrics_sorted_sets`)
+- feat: Add 5 database repository implementations (`DatabaseWorkerRepository`, `DatabaseWorkerHeartbeatRepository`, `DatabaseJobMetricsRepository`, `DatabaseQueueMetricsRepository`, `DatabaseBaselineRepository`) mirroring Redis behavior
+- feat: Add `DatabaseMetricsStore` providing the same API as `RedisMetricsStore` with Eloquent
+- feat: Add `queue-metrics:cleanup-database` command for expired data removal and sorted set trimming
+- feat: Driver-based repository resolution — set `QUEUE_METRICS_STORAGE=database` to auto-bind all database repositories; explicit overrides still take precedence
+- feat: Add `max_samples_per_key` and `cleanup_chunk_size` config options
+- perf: Bulk `incrementHashFields` method reduces lock contention (4 transactions → 1 per job completion)
+- perf: Heartbeat throttling for database driver — skips writes if same state and <10s since last write (~90% reduction in heartbeat queries)
+- fix: Handle `-inf`/`+inf` in sorted set score queries for database driver
+- fix: Resolve all PHPStan errors in database driver (122 errors → 0)
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.4.0...v2.5.0
 
@@ -187,12 +206,12 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add `workerMemoryLimitMb` to `JobMetricsCompleted` and `JobMetricsFailed` events — enables downstream consumers to calculate memory utilization percentage (e.g. 256/512 MB = 50%)
-* refactor: Extract duplicated `getWorkerMemoryLimitMb()` into shared `MemoryLimitParser` utility
-* fix: Resolve PHPStan level 9 errors — `ini_get()` never returns `false` for known settings
-* tests: Add comprehensive `MemoryLimitParser` tests (M/G/K/bytes/lowercase/unlimited)
-* tests: Update event tests to cover `workerMemoryLimitMb` property
-* docs: Document `workerMemoryLimitMb` in events reference
+- feat: Add `workerMemoryLimitMb` to `JobMetricsCompleted` and `JobMetricsFailed` events — enables downstream consumers to calculate memory utilization percentage (e.g. 256/512 MB = 50%)
+- refactor: Extract duplicated `getWorkerMemoryLimitMb()` into shared `MemoryLimitParser` utility
+- fix: Resolve PHPStan level 9 errors — `ini_get()` never returns `false` for known settings
+- tests: Add comprehensive `MemoryLimitParser` tests (M/G/K/bytes/lowercase/unlimited)
+- tests: Update event tests to cover `workerMemoryLimitMb` property
+- docs: Document `workerMemoryLimitMb` in events reference
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.3.0...v2.4.0
 
@@ -200,11 +219,11 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add `JobMetricsFailed` event with per-job metrics (duration, memory, CPU, exception) for downstream consumers like queue-monitor
-* feat: Add `JobMetricsCompleted` event (existed but was never committed)
-* fix: Stop ProcessMetrics tracker on job failure — `ProcessMetrics::start()` was called in `JobProcessingListener` but `ProcessMetrics::stop()` was only called on success, leaking trackers on failure
-* fix: Resolve 17 pre-existing PHPStan errors from named args in `Dispatchable::dispatch()` calls
-* docs: Document `JobMetricsCompleted` and `JobMetricsFailed` events
+- feat: Add `JobMetricsFailed` event with per-job metrics (duration, memory, CPU, exception) for downstream consumers like queue-monitor
+- feat: Add `JobMetricsCompleted` event (existed but was never committed)
+- fix: Stop ProcessMetrics tracker on job failure — `ProcessMetrics::start()` was called in `JobProcessingListener` but `ProcessMetrics::stop()` was only called on success, leaking trackers on failure
+- fix: Resolve 17 pre-existing PHPStan errors from named args in `Dispatchable::dispatch()` calls
+- docs: Document `JobMetricsCompleted` and `JobMetricsFailed` events
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.2.0...v2.3.0
 
@@ -212,9 +231,9 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add Laravel 13 support with orchestra/testbench ^11.0
-* ci: Add Laravel 13 to test matrix (unit + Redis integration)
-* docs: Update version references in README and documentation
+- feat: Add Laravel 13 support with orchestra/testbench ^11.0
+- ci: Add Laravel 13 to test matrix (unit + Redis integration)
+- docs: Update version references in README and documentation
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.1.1...v2.2.0
 
@@ -222,11 +241,11 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Wrap `$serverKey` in array for `PipelineWrapper::addToSet()` in `recordHostnameMetrics()` — caused `TypeError` in production
-* fix: Resolve PHPStan level 9 errors (`new static` → `new self`, typed array extraction in `PrometheusService`)
-* ci: Add `pull_request` triggers to PHPStan, Pint, and test workflows so they gate PRs
-* ci: Limit `push` triggers to `main` branch to prevent duplicate CI runs
-* ci: Add concurrency groups to cancel stale workflow runs
+- fix: Wrap `$serverKey` in array for `PipelineWrapper::addToSet()` in `recordHostnameMetrics()` — caused `TypeError` in production
+- fix: Resolve PHPStan level 9 errors (`new static` → `new self`, typed array extraction in `PrometheusService`)
+- ci: Add `pull_request` triggers to PHPStan, Pint, and test workflows so they gate PRs
+- ci: Limit `push` triggers to `main` branch to prevent duplicate CI runs
+- ci: Add concurrency groups to cancel stale workflow runs
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.1.0...v2.1.1
 
@@ -234,9 +253,9 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Cast CLI option and config values to int in `CleanupStaleWorkersCommand` — `$this->option()` returns `string|null`, but `cleanupStaleWorkers()` requires `int`
-* fix: Extract depth integer from nested array in `RecordTrendDataCommand` — `getAllQueuesWithMetrics()` returns depth as `['total' => ..., 'pending' => ...]`, but `execute()` expects `int`
-* tests: Add unit tests for both commands
+- fix: Cast CLI option and config values to int in `CleanupStaleWorkersCommand` — `$this->option()` returns `string|null`, but `cleanupStaleWorkers()` requires `int`
+- fix: Extract depth integer from nested array in `RecordTrendDataCommand` — `getAllQueuesWithMetrics()` returns depth as `['total' => ..., 'pending' => ...]`, but `execute()` expects `int`
+- tests: Add unit tests for both commands
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v2.0.0...v2.1.0
 
@@ -244,11 +263,11 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* chore(deps): bump dependabot/fetch-metadata from 2.4.0 to 2.5.0 by @dependabot[bot] in https://github.com/cboxdk/laravel-queue-metrics/pull/2
+- chore(deps): bump dependabot/fetch-metadata from 2.4.0 to 2.5.0 by @dependabot[bot] in https://github.com/cboxdk/laravel-queue-metrics/pull/2
 
 ### New Contributors
 
-* @dependabot[bot] made their first contribution in https://github.com/cboxdk/laravel-queue-metrics/pull/2
+- @dependabot[bot] made their first contribution in https://github.com/cboxdk/laravel-queue-metrics/pull/2
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/commits/v2.0.0
 
@@ -256,11 +275,10 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Cast job IDs to string in all listeners for database queue driver compatibility
-  - Laravel's database queue driver returns int job IDs while Redis/SQS return strings
-  - All listeners now cast `$job->getJobId()` to string for consistent handling
-  - Repository interfaces accept `string|int` with internal string casting
-  
+- fix: Cast job IDs to string in all listeners for database queue driver compatibility
+    - Laravel's database queue driver returns int job IDs while Redis/SQS return strings
+    - All listeners now cast `$job->getJobId()` to string for consistent handling
+    - Repository interfaces accept `string|int` with internal string casting
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.4.0...v1.5.0
 
@@ -268,10 +286,9 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Cast job IDs to string in all listeners for consistency
-  - Ensures consistent string type for job IDs throughout listener logic
-  - Fixes potential type issues with database queue driver returning int IDs
-  
+- fix: Cast job IDs to string in all listeners for consistency
+    - Ensures consistent string type for job IDs throughout listener logic
+    - Fixes potential type issues with database queue driver returning int IDs
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.4.1...v1.4.2
 
@@ -279,10 +296,9 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Accept both string and int job IDs from Laravel queue drivers
-  - Laravel's database queue driver returns int job IDs while Redis/SQS drivers return string IDs
-  - Changed `$jobId` parameter type from `string` to `string|int` in all actions and repository interfaces
-  
+- fix: Accept both string and int job IDs from Laravel queue drivers
+    - Laravel's database queue driver returns int job IDs while Redis/SQS drivers return string IDs
+    - Changed `$jobId` parameter type from `string` to `string|int` in all actions and repository interfaces
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.4.0...v1.4.1
 
@@ -290,8 +306,8 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* feat: Add PHP 8.5 support
-* Update all dependencies to latest versions
+- feat: Add PHP 8.5 support
+- Update all dependencies to latest versions
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.3.1...v1.4.0
 
@@ -299,12 +315,11 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix: Achieve PHPStan Level 9 compliance with empty baseline
-  - Remove redundant type checks and operators
-  - Add proper type annotations and validation guards
-  - Fix Carbon timestamp casting for binary operations
-  - Clear baseline from 32 errors to 0
-  
+- fix: Achieve PHPStan Level 9 compliance with empty baseline
+    - Remove redundant type checks and operators
+    - Add proper type annotations and validation guards
+    - Fix Carbon timestamp casting for binary operations
+    - Clear baseline from 32 errors to 0
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.3.0...v1.3.1
 
@@ -312,7 +327,7 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* refactor!: Restructure metrics response for clear abstraction separation by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/3
+- refactor!: Restructure metrics response for clear abstraction separation by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/3
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.2.0...v1.3.0
 
@@ -320,7 +335,7 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* Fix race conditions and implement queue metrics aggregation by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/2
+- Fix race conditions and implement queue metrics aggregation by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/2
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v1.1.0...v1.2.0
 
@@ -328,11 +343,11 @@ When Laravel fires `JobDebounced` (between `JobProcessing` and `JobProcessed`), 
 
 ### What's Changed
 
-* fix(redis): use spread operator for variadic Redis set operations by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/1
+- fix(redis): use spread operator for variadic Redis set operations by @sylvesterdamgaard in https://github.com/cboxdk/laravel-queue-metrics/pull/1
 
 ### New Contributors
 
-* @sylvesterdamgaard made their first contribution in https://github.com/cboxdk/laravel-queue-metrics/pull/1
+- @sylvesterdamgaard made their first contribution in https://github.com/cboxdk/laravel-queue-metrics/pull/1
 
 **Full Changelog**: https://github.com/cboxdk/laravel-queue-metrics/compare/v0.0.1...v1.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
     "require": {
         "php": "^8.3|^8.4|^8.5",
         "cboxdk/system-metrics": "^3.0",
-        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^13.0",
         "spatie/laravel-package-tools": "^1.16",
         "spatie/laravel-prometheus": "^1.3"
     },
     "require-dev": {
         "cboxdk/laravel-telemetry": "^1.0.0",
         "larastan/larastan": "^3.0",
-        "laravel/pint": "^1.14",
+        "laravel/pint": "^1.18",
         "nunomaduro/collision": "^8.8",
-        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",

--- a/src/Services/LaravelQueueInspector.php
+++ b/src/Services/LaravelQueueInspector.php
@@ -20,8 +20,7 @@ final readonly class LaravelQueueInspector implements QueueInspector
 {
     public function __construct(
         private QueueFactory $queueFactory,
-    ) {
-    }
+    ) {}
 
     public function getQueueDepth(string $connection, string $queue): QueueDepthData
     {

--- a/src/Services/LaravelQueueInspector.php
+++ b/src/Services/LaravelQueueInspector.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueDepthData;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Illuminate\Queue\RedisQueue;
+use Illuminate\Redis\Connections\Connection;
 use ReflectionClass;
 use ReflectionException;
 
@@ -19,7 +20,8 @@ final readonly class LaravelQueueInspector implements QueueInspector
 {
     public function __construct(
         private QueueFactory $queueFactory,
-    ) {}
+    ) {
+    }
 
     public function getQueueDepth(string $connection, string $queue): QueueDepthData
     {
@@ -363,18 +365,28 @@ final readonly class LaravelQueueInspector implements QueueInspector
                 $prefix = 'queues';
             }
 
+            // On a cluster, Laravel's RedisQueue wraps unbraced queue names in a {hash tag}
+            // (getQueueRedisKey), so jobs live at queues:{name}. Mirror that or reads return 0.
+            $queueKey = $queueName;
+            if ($redis instanceof Connection
+                && $redis->isCluster()
+                && ! Connection::hasHashTag($queueKey)
+            ) {
+                $queueKey = '{'.$queueKey.'}';
+            }
+
             // Get pending jobs count
-            $pendingKey = "{$prefix}:{$queueName}";
+            $pendingKey = "{$prefix}:{$queueKey}";
             $pendingCount = $redis->llen($pendingKey);
             $pendingJobs = is_int($pendingCount) ? $pendingCount : 0;
 
             // Get reserved jobs count
-            $reservedKey = "{$prefix}:{$queueName}:reserved";
+            $reservedKey = "{$prefix}:{$queueKey}:reserved";
             $reservedCount = $redis->zcard($reservedKey);
             $reservedJobs = is_int($reservedCount) ? $reservedCount : 0;
 
             // Get delayed jobs count
-            $delayedKey = "{$prefix}:{$queueName}:delayed";
+            $delayedKey = "{$prefix}:{$queueKey}:delayed";
             $delayedCount = $redis->zcard($delayedKey);
             $delayedJobs = is_int($delayedCount) ? $delayedCount : 0;
 

--- a/src/Support/PipelineWrapper.php
+++ b/src/Support/PipelineWrapper.php
@@ -7,7 +7,7 @@ namespace Cbox\LaravelQueueMetrics\Support;
 /**
  * Wrapper around Laravel Redis pipeline for batch operations.
  *
- * @phpstan-type PipelineType \Redis|\Illuminate\Redis\Connections\PhpRedisConnection
+ * @phpstan-type PipelineType \Redis|\RedisCluster|\Illuminate\Redis\Connections\Connection|\Illuminate\Redis\Connections\PhpRedisConnection
  */
 final class PipelineWrapper
 {
@@ -16,7 +16,8 @@ final class PipelineWrapper
      */
     public function __construct(
         private mixed $pipe,
-    ) {}
+    ) {
+    }
 
     /**
      * @param  array<string, mixed>  $data

--- a/src/Support/PipelineWrapper.php
+++ b/src/Support/PipelineWrapper.php
@@ -16,8 +16,7 @@ final class PipelineWrapper
      */
     public function __construct(
         private mixed $pipe,
-    ) {
-    }
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data

--- a/src/Support/RedisMetricsStore.php
+++ b/src/Support/RedisMetricsStore.php
@@ -346,8 +346,11 @@ final class RedisMetricsStore
      * Execute commands in a Redis transaction (MULTI/EXEC).
      * Ensures all commands are executed atomically.
      *
+     * On a cluster connection the commands are issued individually (no MULTI), so the batched
+     * incr/expire calls are not atomic and an empty array is returned instead of the exec result.
+     *
      * @param  callable(PipelineWrapper): void  $callback
-     * @return array<int, mixed> Results of executed commands
+     * @return array<int, mixed> Results of executed commands, or an empty array on a cluster
      */
     public function transaction(callable $callback): array
     {

--- a/src/Support/RedisMetricsStore.php
+++ b/src/Support/RedisMetricsStore.php
@@ -32,6 +32,14 @@ final class RedisMetricsStore
     }
 
     /**
+     * Whether the underlying connection is backed by a Redis Cluster client.
+     */
+    private function isCluster(): bool
+    {
+        return $this->getRedis()->client() instanceof \RedisCluster;
+    }
+
+    /**
      * Get prefix (lazy loaded).
      */
     private function getPrefix(): string
@@ -246,15 +254,23 @@ final class RedisMetricsStore
     public function scanKeys(string $pattern): array
     {
         // Get the underlying PhpRedis client - it includes Redis connection prefix
-        /** @var \Redis $client */
+        /** @var \Redis|\RedisCluster $client */
         $client = $this->getRedis()->client();
 
-        // Get Laravel's Redis connection prefix (e.g., 'laravel_database_')
-        $connectionPrefix = $this->getRedis()->_prefix('');
+        // Combine Laravel's Redis connection prefix (e.g., 'laravel_database_') with our pattern
+        $fullPattern = $this->getRedis()->_prefix('').$pattern;
 
-        // Combine connection prefix with our pattern
-        $fullPattern = $connectionPrefix.$pattern;
+        return $client instanceof \RedisCluster
+            ? $this->scanClusterKeys($client, $fullPattern)
+            : $this->scanSingleNodeKeys($client, $fullPattern);
+    }
 
+    /**
+     * @param  \Redis  $client
+     * @return array<int, string>
+     */
+    private function scanSingleNodeKeys(mixed $client, string $fullPattern): array
+    {
         $keys = [];
         $cursor = null;
 
@@ -278,8 +294,47 @@ final class RedisMetricsStore
         return $keys;
     }
 
+    /**
+     * RedisCluster has no cluster-wide SCAN; every master must be scanned individually.
+     *
+     * @return array<int, string>
+     */
+    private function scanClusterKeys(\RedisCluster $client, string $fullPattern): array
+    {
+        $keys = [];
+
+        // _masters() returns [host, port] pairs, which is the node argument scan() expects.
+        foreach ($client->_masters() as $master) {
+            $cursor = null;
+
+            do {
+                /** @var array<int, string>|false $result */
+                $result = $client->scan($cursor, $master, $fullPattern, 1000);
+
+                if ($result === false) {
+                    break;
+                }
+
+                if ($result !== []) {
+                    $keys = array_merge($keys, $result);
+                }
+            } while ($cursor > 0);
+        }
+
+        // Dedupe across masters to guard against resharding during the scan.
+        return array_values(array_unique($keys));
+    }
+
     public function pipeline(callable $callback): void
     {
+        // A cluster connection cannot pipeline slot-routed commands through a single node;
+        // run the commands sequentially instead. The single-node path is unchanged.
+        if ($this->isCluster()) {
+            $callback(new PipelineWrapper($this->getRedis()));
+
+            return;
+        }
+
         // @phpstan-ignore-next-line - PhpRedis pipeline accepts no parameters in newer versions
         $this->getRedis()->pipeline(function ($pipe) use ($callback) {
             $wrapper = new PipelineWrapper($pipe);
@@ -297,6 +352,15 @@ final class RedisMetricsStore
     public function transaction(callable $callback): array
     {
         $redis = $this->getRedis();
+
+        // A node-less MULTI cannot reconcile with slot-routed commands on a cluster, and the
+        // metrics keys span multiple slots. Drop atomicity and issue commands individually.
+        // The single-node MULTI/EXEC path below is unchanged.
+        if ($this->isCluster()) {
+            $callback(new PipelineWrapper($redis));
+
+            return [];
+        }
 
         // Laravel Redis uses multi() and exec() for transactions
         $redis->multi();

--- a/tests/Feature/RedisClusterCompatTest.php
+++ b/tests/Feature/RedisClusterCompatTest.php
@@ -9,11 +9,11 @@ use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
 use Illuminate\Support\Facades\Redis;
 
 /**
- * Redis Cluster compatibility regression tests
+ * Redis Cluster compatibility tests.
  *
  * These run against whichever Redis the environment provides: a single node normally, or a
- * real cluster when REDIS_CLUSTER_HOSTS_AND_PORTS is set (see the cluster CI job). Assertions
- * hold in both modes; the cluster run is the one that fails before the fixes land.
+ * real cluster when REDIS_CLUSTER_HOSTS_AND_PORTS is set (see the cluster CI job). The same
+ * assertions must hold in both modes.
  */
 beforeEach(function () {
     if (! getenv('REDIS_AVAILABLE')) {
@@ -34,7 +34,7 @@ beforeEach(function () {
     Redis::connection('default')->flushdb();
 });
 
-// Issue A — scanKeys must not throw and must return written keys on a cluster.
+// scanKeys must not throw and must return written keys on a cluster.
 it('scans keys across the keyspace', function () {
     $store = app(RedisMetricsStore::class);
 
@@ -46,7 +46,7 @@ it('scans keys across the keyspace', function () {
     expect($keys)->toHaveCount(2);
 })->group('redis');
 
-// Issue B — depth reads the {hash tag} key Laravel's RedisQueue writes on a cluster.
+// Depth must read the {hash tag} key Laravel's RedisQueue writes on a cluster.
 it('reads queue depth for an unbraced queue name', function () {
     $queue = app('queue')->connection('redis');
     $queue->pushRaw('{"job":"a"}', 'depthtest');
@@ -58,7 +58,7 @@ it('reads queue depth for an unbraced queue name', function () {
     expect($depth->pendingJobs)->toBe(3);
 })->group('redis');
 
-// Issue B — an already-braced queue name must not be double-wrapped.
+// An already-braced queue name must not be double-wrapped.
 it('reads queue depth for an already-braced queue name without double wrapping', function () {
     $queue = app('queue')->connection('redis');
     $queue->pushRaw('{"job":"a"}', '{braced}');
@@ -69,7 +69,7 @@ it('reads queue depth for an already-braced queue name without double wrapping',
     expect($depth->pendingJobs)->toBe(2);
 })->group('redis');
 
-// Issue C — transaction() writes succeed and are readable on a cluster.
+// transaction() writes must succeed and be readable on a cluster.
 it('writes through a transaction and reads the result back', function () {
     $repository = app(JobMetricsRepository::class);
     $store = app(RedisMetricsStore::class);
@@ -81,7 +81,7 @@ it('writes through a transaction and reads the result back', function () {
     expect($store->getHash($metricsKey)['total_queued'])->toBe('1');
 })->group('redis');
 
-// Issue C — pipeline() writes succeed and are readable on a cluster.
+// pipeline() writes must succeed and be readable on a cluster.
 it('writes through a pipeline and reads the result back', function () {
     $store = app(RedisMetricsStore::class);
     $key = $store->key('pipeline', 'example');
@@ -94,7 +94,7 @@ it('writes through a pipeline and reads the result back', function () {
 })->group('redis');
 
 /**
- * Invoke the reflection-based depth path directly so Issue B is covered even on Laravel
+ * Invoke the reflection-based depth path directly so it is covered even on Laravel
  * versions whose RedisQueue exposes native size methods (which bypass getRedisQueueDepth).
  */
 function invokeRedisQueueDepth(object $queue, string $queueName): QueueDepthData

--- a/tests/Feature/RedisClusterCompatTest.php
+++ b/tests/Feature/RedisClusterCompatTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueDepthData;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Cbox\LaravelQueueMetrics\Services\LaravelQueueInspector;
+use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Redis Cluster compatibility regression tests
+ *
+ * These run against whichever Redis the environment provides: a single node normally, or a
+ * real cluster when REDIS_CLUSTER_HOSTS_AND_PORTS is set (see the cluster CI job). Assertions
+ * hold in both modes; the cluster run is the one that fails before the fixes land.
+ */
+beforeEach(function () {
+    if (! getenv('REDIS_AVAILABLE')) {
+        $this->markTestSkipped('Requires Redis - run with redis group');
+    }
+
+    config()->set('queue-metrics.enabled', true);
+    config()->set('queue-metrics.storage.driver', 'redis');
+    config()->set('queue-metrics.storage.connection', 'default');
+
+    config()->set('queue.connections.redis', [
+        'driver' => 'redis',
+        'connection' => 'default',
+        'queue' => 'default',
+        'retry_after' => 90,
+    ]);
+
+    Redis::connection('default')->flushdb();
+});
+
+// Issue A — scanKeys must not throw and must return written keys on a cluster.
+it('scans keys across the keyspace', function () {
+    $store = app(RedisMetricsStore::class);
+
+    $store->set('queue_metrics:scan:a', '1');
+    $store->set('queue_metrics:scan:b', '1');
+
+    $keys = $store->scanKeys('queue_metrics:scan:*');
+
+    expect($keys)->toHaveCount(2);
+})->group('redis');
+
+// Issue B — depth reads the {hash tag} key Laravel's RedisQueue writes on a cluster.
+it('reads queue depth for an unbraced queue name', function () {
+    $queue = app('queue')->connection('redis');
+    $queue->pushRaw('{"job":"a"}', 'depthtest');
+    $queue->pushRaw('{"job":"b"}', 'depthtest');
+    $queue->pushRaw('{"job":"c"}', 'depthtest');
+
+    $depth = invokeRedisQueueDepth($queue, 'depthtest');
+
+    expect($depth->pendingJobs)->toBe(3);
+})->group('redis');
+
+// Issue B — an already-braced queue name must not be double-wrapped.
+it('reads queue depth for an already-braced queue name without double wrapping', function () {
+    $queue = app('queue')->connection('redis');
+    $queue->pushRaw('{"job":"a"}', '{braced}');
+    $queue->pushRaw('{"job":"b"}', '{braced}');
+
+    $depth = invokeRedisQueueDepth($queue, '{braced}');
+
+    expect($depth->pendingJobs)->toBe(2);
+})->group('redis');
+
+// Issue C — transaction() writes succeed and are readable on a cluster.
+it('writes through a transaction and reads the result back', function () {
+    $repository = app(JobMetricsRepository::class);
+    $store = app(RedisMetricsStore::class);
+
+    $repository->recordStart('cluster-job-1', 'App\\Jobs\\Example', 'redis', 'default', now());
+
+    $metricsKey = $store->key('jobs', 'redis', 'default', 'App\\Jobs\\Example');
+
+    expect($store->getHash($metricsKey)['total_queued'])->toBe('1');
+})->group('redis');
+
+// Issue C — pipeline() writes succeed and are readable on a cluster.
+it('writes through a pipeline and reads the result back', function () {
+    $store = app(RedisMetricsStore::class);
+    $key = $store->key('pipeline', 'example');
+
+    $store->pipeline(function ($pipe) use ($key) {
+        $pipe->setHash($key, ['field' => 'value']);
+    });
+
+    expect($store->getHash($key))->toMatchArray(['field' => 'value']);
+})->group('redis');
+
+/**
+ * Invoke the reflection-based depth path directly so Issue B is covered even on Laravel
+ * versions whose RedisQueue exposes native size methods (which bypass getRedisQueueDepth).
+ */
+function invokeRedisQueueDepth(object $queue, string $queueName): QueueDepthData
+{
+    $inspector = new LaravelQueueInspector(app('queue'));
+
+    $method = (new ReflectionClass($inspector))->getMethod('getRedisQueueDepth');
+    $method->setAccessible(true);
+
+    /** @var QueueDepthData $depth */
+    $depth = $method->invoke($inspector, $queue, 'redis', $queueName);
+
+    return $depth;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,8 +39,8 @@ class TestCase extends Orchestra
     /**
      * Configure the `default` Redis connection.
      *
-     * Mirrors Laravel's InteractsWithRedis: when REDIS_CLUSTER_HOSTS_AND_PORTS is set the
-     * connection is backed by a real Redis Cluster, otherwise a single node. The same redis
+     * When REDIS_CLUSTER_HOSTS_AND_PORTS is set the connection is backed
+     * by a real Redis Cluster, otherwise a single node. The same redis
      * test suite therefore runs against both modes depending on the CI job's environment.
      */
     private function configureRedis($app): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,10 +33,55 @@ class TestCase extends Orchestra
         // Disable queue metrics during tests to avoid Redis connection attempts
         config()->set('queue-metrics.enabled', false);
 
-        /*
-         foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/../database/migrations') as $migration) {
-            (include $migration->getRealPath())->up();
-         }
-         */
+        $this->configureRedis($app);
+    }
+
+    /**
+     * Configure the `default` Redis connection.
+     *
+     * Mirrors Laravel's InteractsWithRedis: when REDIS_CLUSTER_HOSTS_AND_PORTS is set the
+     * connection is backed by a real Redis Cluster, otherwise a single node. The same redis
+     * test suite therefore runs against both modes depending on the CI job's environment.
+     */
+    private function configureRedis($app): void
+    {
+        $clusterHosts = getenv('REDIS_CLUSTER_HOSTS_AND_PORTS');
+
+        if (is_string($clusterHosts) && $clusterHosts !== '') {
+            config()->set('database.redis', [
+                'client' => 'phpredis',
+                'options' => [
+                    'cluster' => 'redis',
+                    'prefix' => 'lqm_test_',
+                ],
+                'clusters' => [
+                    'default' => array_map(
+                        static fn (string $hostAndPort): array => [
+                            'host' => explode(':', $hostAndPort)[0],
+                            'port' => (int) explode(':', $hostAndPort)[1],
+                        ],
+                        explode(',', $clusterHosts),
+                    ),
+                ],
+            ]);
+
+            return;
+        }
+
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = getenv('REDIS_PORT') ?: '6379';
+
+        config()->set('database.redis', [
+            'client' => 'phpredis',
+            'options' => [
+                'prefix' => 'lqm_test_',
+            ],
+            'default' => [
+                'host' => $host,
+                'port' => (int) $port,
+                'database' => 0,
+                'timeout' => 1.0,
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
The store assumes a single-node `\Redis` client, so three things break on a `\RedisCluster` connection:

(A) `RedisMetricsStore::scanKeys()` calls `scan()` with the single-node arg order (`RedisCluster::scan()` needs a node) → `TypeError` every autoscale cycle;

(B) `LaravelQueueInspector::getRedisQueueDepth()` builds `queues:name` keys without the `{hash tag}` Laravel's `RedisQueue` auto-applies on a cluster, so depth reads `0` and the autoscaler never scales those queues;

(C) the store's `transaction()`/`pipeline()` writes use a node-less `MULTI`, which can't reconcile with slot-routed commands on a multi-shard cluster.

Each fix branches on the cluster client and leaves the single-node path unchanged: scan every master, apply the `isCluster() + hasHashTag()` rule to depth keys, and make the write path cluster-safe (bind the `MULTI` to the shared hash-tag slot, or issue commands individually). Adds cluster + non-cluster tests for all three.