### PR TITLE
Stop the recorded snapshot zero-overwriting live queue state in getQueueMetrics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-queue-metrics` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- `getQueueMetrics()` no longer reports `pending`, `oldest_job_age`, `depth`, `scheduled`, and `reserved` as zero whenever a recorded snapshot exists. The snapshot reader now returns only the fields the snapshot actually stores, live queue state wins the merge for state-shaped fields, and `getQueueState()` now reads real depth and job-age numbers from the queue inspector instead of hardcoding zeros. Previously any snapshot (written every collection cycle) zeroed out the live backlog in the reported metrics.
+
 ## v3.2.1 - Documentation fixes - 2026-07-15
 
 ### Fixed

--- a/src/Repositories/DatabaseQueueMetricsRepository.php
+++ b/src/Repositories/DatabaseQueueMetricsRepository.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMetrics\Repositories;
 
 use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
 use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
 use Cbox\LaravelQueueMetrics\Models\MetricsHash;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
 use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
 use Cbox\LaravelQueueMetrics\Support\MetricsConstants;
-use Illuminate\Support\Facades\Queue;
 
 /**
  * Database-based implementation of queue metrics repository.
@@ -19,6 +19,7 @@ final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepos
 {
     public function __construct(
         private DatabaseMetricsStore $store,
+        private QueueInspector $queueInspector,
     ) {}
 
     /**
@@ -26,19 +27,14 @@ final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepos
      */
     public function getQueueState(string $connection, string $queue): array
     {
-        $queueManager = Queue::connection($connection);
+        $depth = $this->queueInspector->getQueueDepth($connection, $queue);
 
-        // Get queue size (pending jobs)
-        $size = $queueManager->size($queue);
-
-        // For detailed metrics, we'd need to query the queue backend directly
-        // This is a simplified version - extend based on your queue driver
         return [
-            'depth' => $size,
-            'pending' => $size,
-            'scheduled' => 0,
-            'reserved' => 0,
-            'oldest_job_age' => 0,
+            'depth' => $depth->totalJobs(),
+            'pending' => $depth->pendingJobs,
+            'scheduled' => $depth->delayedJobs,
+            'reserved' => $depth->reservedJobs,
+            'oldest_job_age' => (int) ($depth->secondsOldestPendingJob() ?? 0),
         ];
     }
 
@@ -72,6 +68,13 @@ final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepos
     }
 
     /**
+     * Return only the fields the stored snapshot actually contains.
+     *
+     * The snapshot writer records throughput and failure data, never queue
+     * depth. Zero-defaulting the absent depth fields here let a stale zero
+     * overwrite the live queue state in getQueueMetrics(), reporting an
+     * empty queue while a real backlog existed.
+     *
      * @return array<string, mixed>
      */
     public function getLatestMetrics(string $connection, string $queue): array
@@ -86,21 +89,25 @@ final readonly class DatabaseQueueMetricsRepository implements QueueMetricsRepos
             return [];
         }
 
-        return [
-            'depth' => (int) ($data['depth'] ?? 0),
-            'pending' => (int) ($data['pending'] ?? 0),
-            'scheduled' => (int) ($data['scheduled'] ?? 0),
-            'reserved' => (int) ($data['reserved'] ?? 0),
-            'oldest_job_age' => (int) ($data['oldest_job_age'] ?? 0),
-            'throughput_per_minute' => (float) ($data['throughput_per_minute'] ?? 0.0),
-            'avg_duration' => (float) ($data['avg_duration'] ?? 0.0),
-            'failure_rate' => (float) ($data['failure_rate'] ?? 0.0),
-            'utilization_rate' => (float) ($data['utilization_rate'] ?? 0.0),
-            'active_workers' => (int) ($data['active_workers'] ?? 0),
-            'recorded_at' => isset($data['recorded_at'])
-                ? Carbon::createFromTimestamp((int) $data['recorded_at'])
-                : null,
-        ];
+        $metrics = [];
+
+        foreach (['depth', 'pending', 'scheduled', 'reserved', 'oldest_job_age', 'active_workers'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $metrics[$field] = (int) $data[$field];
+            }
+        }
+
+        foreach (['throughput_per_minute', 'avg_duration', 'failure_rate', 'utilization_rate'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $metrics[$field] = (float) $data[$field];
+            }
+        }
+
+        if (isset($data['recorded_at'])) {
+            $metrics['recorded_at'] = Carbon::createFromTimestamp((int) $data['recorded_at']);
+        }
+
+        return $metrics;
     }
 
     /**

--- a/src/Repositories/RedisQueueMetricsRepository.php
+++ b/src/Repositories/RedisQueueMetricsRepository.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMetrics\Repositories;
 
 use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
 use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
 use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
 use Cbox\LaravelQueueMetrics\Support\MetricsConstants;
 use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
-use Illuminate\Support\Facades\Queue;
 
 /**
  * Redis-based implementation of queue metrics repository.
@@ -18,6 +18,7 @@ final readonly class RedisQueueMetricsRepository implements QueueMetricsReposito
 {
     public function __construct(
         private RedisMetricsStore $redis,
+        private QueueInspector $queueInspector,
     ) {}
 
     /**
@@ -25,19 +26,14 @@ final readonly class RedisQueueMetricsRepository implements QueueMetricsReposito
      */
     public function getQueueState(string $connection, string $queue): array
     {
-        $queueManager = Queue::connection($connection);
+        $depth = $this->queueInspector->getQueueDepth($connection, $queue);
 
-        // Get queue size (pending jobs)
-        $size = $queueManager->size($queue);
-
-        // For detailed metrics, we'd need to query the queue backend directly
-        // This is a simplified version - extend based on your queue driver
         return [
-            'depth' => $size,
-            'pending' => $size,
-            'scheduled' => 0,
-            'reserved' => 0,
-            'oldest_job_age' => 0,
+            'depth' => $depth->totalJobs(),
+            'pending' => $depth->pendingJobs,
+            'scheduled' => $depth->delayedJobs,
+            'reserved' => $depth->reservedJobs,
+            'oldest_job_age' => (int) ($depth->secondsOldestPendingJob() ?? 0),
         ];
     }
 
@@ -71,6 +67,13 @@ final readonly class RedisQueueMetricsRepository implements QueueMetricsReposito
     }
 
     /**
+     * Return only the fields the stored snapshot actually contains.
+     *
+     * The snapshot writer records throughput and failure data, never queue
+     * depth. Zero-defaulting the absent depth fields here let a stale zero
+     * overwrite the live queue state in getQueueMetrics(), reporting an
+     * empty queue while a real backlog existed.
+     *
      * @return array<string, mixed>
      */
     public function getLatestMetrics(string $connection, string $queue): array
@@ -85,21 +88,25 @@ final readonly class RedisQueueMetricsRepository implements QueueMetricsReposito
             return [];
         }
 
-        return [
-            'depth' => (int) ($data['depth'] ?? 0),
-            'pending' => (int) ($data['pending'] ?? 0),
-            'scheduled' => (int) ($data['scheduled'] ?? 0),
-            'reserved' => (int) ($data['reserved'] ?? 0),
-            'oldest_job_age' => (int) ($data['oldest_job_age'] ?? 0),
-            'throughput_per_minute' => (float) ($data['throughput_per_minute'] ?? 0.0),
-            'avg_duration' => (float) ($data['avg_duration'] ?? 0.0),
-            'failure_rate' => (float) ($data['failure_rate'] ?? 0.0),
-            'utilization_rate' => (float) ($data['utilization_rate'] ?? 0.0),
-            'active_workers' => (int) ($data['active_workers'] ?? 0),
-            'recorded_at' => isset($data['recorded_at'])
-                ? Carbon::createFromTimestamp((int) $data['recorded_at'])
-                : null,
-        ];
+        $metrics = [];
+
+        foreach (['depth', 'pending', 'scheduled', 'reserved', 'oldest_job_age', 'active_workers'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $metrics[$field] = (int) $data[$field];
+            }
+        }
+
+        foreach (['throughput_per_minute', 'avg_duration', 'failure_rate', 'utilization_rate'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $metrics[$field] = (float) $data[$field];
+            }
+        }
+
+        if (isset($data['recorded_at'])) {
+            $metrics['recorded_at'] = Carbon::createFromTimestamp((int) $data['recorded_at']);
+        }
+
+        return $metrics;
     }
 
     /**

--- a/src/Services/QueueMetricsQueryService.php
+++ b/src/Services/QueueMetricsQueryService.php
@@ -39,7 +39,10 @@ final readonly class QueueMetricsQueryService
         $metrics = $this->queueMetricsRepository->getLatestMetrics($connection, $queue);
         $health = $this->queueMetricsRepository->getHealthStatus($connection, $queue);
 
-        return QueueMetricsData::fromArray(array_merge($state, $metrics, [
+        // Live state wins over the recorded snapshot for state-shaped fields:
+        // a snapshot is always staler than the queue read made moments ago,
+        // and a snapshot missing those fields must never mask them as zero.
+        return QueueMetricsData::fromArray(array_merge($metrics, $state, [
             'connection' => $connection,
             'queue' => $queue,
             'health' => $health,

--- a/tests/Feature/Repositories/DatabaseQueueMetricsRepositoryTest.php
+++ b/tests/Feature/Repositories/DatabaseQueueMetricsRepositoryTest.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueDepthData;
 use Cbox\LaravelQueueMetrics\Events\HealthScoreChanged;
 use Cbox\LaravelQueueMetrics\Repositories\DatabaseQueueMetricsRepository;
 use Cbox\LaravelQueueMetrics\Support\DatabaseMetricsStore;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     config()->set('queue-metrics.storage.connection', null);
@@ -18,26 +20,52 @@ beforeEach(function () {
     $addSetExpiry->up();
 
     $this->store = new DatabaseMetricsStore;
-    $this->repo = new DatabaseQueueMetricsRepository($this->store);
+    $this->inspector = Mockery::mock(QueueInspector::class);
+    $this->repo = new DatabaseQueueMetricsRepository($this->store, $this->inspector);
 });
 
 // --- getQueueState ---
 
-test('getQueueState returns depth info from queue driver', function () {
-    Queue::shouldReceive('connection')
-        ->with('redis')
-        ->andReturnSelf();
-
-    Queue::shouldReceive('size')
-        ->with('default')
-        ->andReturn(42);
+test('getQueueState returns live depth info from the queue inspector', function () {
+    $this->inspector->shouldReceive('getQueueDepth')
+        ->with('redis', 'default')
+        ->andReturn(new QueueDepthData(
+            connection: 'redis',
+            queue: 'default',
+            pendingJobs: 42,
+            reservedJobs: 3,
+            delayedJobs: 5,
+            oldestPendingJobAge: Carbon::now()->subSeconds(120),
+            oldestDelayedJobAge: null,
+            measuredAt: Carbon::now(),
+        ));
 
     $state = $this->repo->getQueueState('redis', 'default');
 
-    expect($state['depth'])->toBe(42);
+    expect($state['depth'])->toBe(50);
     expect($state['pending'])->toBe(42);
-    expect($state['scheduled'])->toBe(0);
-    expect($state['reserved'])->toBe(0);
+    expect($state['scheduled'])->toBe(5);
+    expect($state['reserved'])->toBe(3);
+    expect($state['oldest_job_age'])->toBe(120);
+});
+
+test('getQueueState reports zero age for an empty queue', function () {
+    $this->inspector->shouldReceive('getQueueDepth')
+        ->with('redis', 'default')
+        ->andReturn(new QueueDepthData(
+            connection: 'redis',
+            queue: 'default',
+            pendingJobs: 0,
+            reservedJobs: 0,
+            delayedJobs: 0,
+            oldestPendingJobAge: null,
+            oldestDelayedJobAge: null,
+            measuredAt: Carbon::now(),
+        ));
+
+    $state = $this->repo->getQueueState('redis', 'default');
+
+    expect($state['depth'])->toBe(0);
     expect($state['oldest_job_age'])->toBe(0);
 });
 
@@ -77,6 +105,21 @@ test('recordSnapshot stores snapshot and getLatestMetrics retrieves it', functio
 test('getLatestMetrics returns empty array when no snapshot exists', function () {
     $latest = $this->repo->getLatestMetrics('redis', 'default');
     expect($latest)->toBe([]);
+});
+
+test('getLatestMetrics omits fields the snapshot does not store', function () {
+    $this->repo->recordSnapshot('redis', 'default', [
+        'throughput_per_minute' => 5.5,
+        'avg_duration' => 250.0,
+        'failure_rate' => 2.0,
+    ]);
+
+    $latest = $this->repo->getLatestMetrics('redis', 'default');
+
+    expect($latest['throughput_per_minute'])->toBe(5.5)
+        ->and($latest['avg_duration'])->toBe(250.0)
+        ->and($latest['failure_rate'])->toBe(2.0)
+        ->and($latest)->not->toHaveKeys(['depth', 'pending', 'scheduled', 'reserved', 'oldest_job_age', 'active_workers', 'utilization_rate']);
 });
 
 test('recordSnapshot trims sorted set to 1000 entries', function () {

--- a/tests/Feature/Repositories/RedisQueueMetricsRepositoryTest.php
+++ b/tests/Feature/Repositories/RedisQueueMetricsRepositoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Contracts\QueueInspector;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueDepthData;
+use Cbox\LaravelQueueMetrics\Repositories\RedisQueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Support\RedisMetricsStore;
+use Illuminate\Support\Facades\Redis;
+
+beforeEach(function () {
+    if (! getenv('REDIS_AVAILABLE')) {
+        test()->markTestSkipped('Requires Redis - run with redis group');
+    }
+
+    config()->set('queue-metrics.enabled', true);
+    config()->set('queue-metrics.storage.driver', 'redis');
+    config()->set('queue-metrics.storage.connection', 'default');
+
+    Redis::connection('default')->flushdb();
+
+    $this->inspector = Mockery::mock(QueueInspector::class);
+    $this->repo = new RedisQueueMetricsRepository(app(RedisMetricsStore::class), $this->inspector);
+});
+
+test('getQueueState returns live depth info from the queue inspector', function () {
+    $this->inspector->shouldReceive('getQueueDepth')
+        ->with('redis', 'default')
+        ->andReturn(new QueueDepthData(
+            connection: 'redis',
+            queue: 'default',
+            pendingJobs: 42,
+            reservedJobs: 3,
+            delayedJobs: 5,
+            oldestPendingJobAge: Carbon::now()->subSeconds(120),
+            oldestDelayedJobAge: null,
+            measuredAt: Carbon::now(),
+        ));
+
+    $state = $this->repo->getQueueState('redis', 'default');
+
+    expect($state['depth'])->toBe(50)
+        ->and($state['pending'])->toBe(42)
+        ->and($state['scheduled'])->toBe(5)
+        ->and($state['reserved'])->toBe(3)
+        ->and($state['oldest_job_age'])->toBe(120);
+})->group('redis');
+
+test('recordSnapshot stores snapshot and getLatestMetrics retrieves stored fields', function () {
+    $this->repo->recordSnapshot('redis', 'default', [
+        'depth' => 10,
+        'pending' => 8,
+        'scheduled' => 1,
+        'reserved' => 1,
+        'oldest_job_age' => 120,
+        'throughput_per_minute' => 5.5,
+        'avg_duration' => 250.0,
+        'failure_rate' => 2.0,
+        'utilization_rate' => 0.75,
+        'active_workers' => 3,
+    ]);
+
+    $latest = $this->repo->getLatestMetrics('redis', 'default');
+
+    expect($latest['depth'])->toBe(10)
+        ->and($latest['pending'])->toBe(8)
+        ->and($latest['scheduled'])->toBe(1)
+        ->and($latest['reserved'])->toBe(1)
+        ->and($latest['oldest_job_age'])->toBe(120)
+        ->and($latest['throughput_per_minute'])->toBe(5.5)
+        ->and($latest['avg_duration'])->toBe(250.0)
+        ->and($latest['failure_rate'])->toBe(2.0)
+        ->and($latest['utilization_rate'])->toBe(0.75)
+        ->and($latest['active_workers'])->toBe(3)
+        ->and($latest['recorded_at'])->not->toBeNull();
+})->group('redis');
+
+test('getLatestMetrics omits fields the snapshot does not store', function () {
+    $this->repo->recordSnapshot('redis', 'default', [
+        'throughput_per_minute' => 5.5,
+        'avg_duration' => 250.0,
+        'failure_rate' => 2.0,
+    ]);
+
+    $latest = $this->repo->getLatestMetrics('redis', 'default');
+
+    expect($latest['throughput_per_minute'])->toBe(5.5)
+        ->and($latest['avg_duration'])->toBe(250.0)
+        ->and($latest['failure_rate'])->toBe(2.0)
+        ->and($latest)->not->toHaveKeys(['depth', 'pending', 'scheduled', 'reserved', 'oldest_job_age', 'active_workers', 'utilization_rate']);
+})->group('redis');
+
+test('getLatestMetrics returns empty array when no snapshot exists', function () {
+    expect($this->repo->getLatestMetrics('redis', 'default'))->toBe([]);
+})->group('redis');

--- a/tests/Unit/Services/QueueMetricsQueryServiceTest.php
+++ b/tests/Unit/Services/QueueMetricsQueryServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\QueueMetricsRepository;
+use Cbox\LaravelQueueMetrics\Services\QueueMetricsQueryService;
+
+/**
+ * Resolve the service with the repository contract mocked, so the merge
+ * behavior of getQueueMetrics() can be pinned without any storage backend.
+ */
+function queueMetricsServiceWith(array $state, array $latestMetrics): QueueMetricsQueryService
+{
+    $repository = Mockery::mock(QueueMetricsRepository::class);
+    $repository->shouldReceive('getQueueState')->with('redis', 'default')->andReturn($state);
+    $repository->shouldReceive('getLatestMetrics')->with('redis', 'default')->andReturn($latestMetrics);
+    $repository->shouldReceive('getHealthStatus')->with('redis', 'default')->andReturn([
+        'status' => 'warning',
+        'score' => 60.0,
+    ]);
+
+    app()->instance(QueueMetricsRepository::class, $repository);
+
+    return app(QueueMetricsQueryService::class);
+}
+
+test('getQueueMetrics reports live queue state alongside snapshot performance data', function () {
+    $service = queueMetricsServiceWith(
+        state: [
+            'depth' => 152361,
+            'pending' => 152361,
+            'scheduled' => 0,
+            'reserved' => 0,
+            'oldest_job_age' => 83880,
+        ],
+        latestMetrics: [
+            'throughput_per_minute' => 12.5,
+            'avg_duration' => 0.3,
+            'failure_rate' => 1.0,
+            'recorded_at' => Carbon::now(),
+        ],
+    );
+
+    $metrics = $service->getQueueMetrics('redis', 'default');
+
+    expect($metrics->pending)->toBe(152361)
+        ->and($metrics->oldestJobAge)->toBe(83880)
+        ->and($metrics->throughputPerMinute)->toBe(12.5)
+        ->and($metrics->failureRate)->toBe(1.0);
+});
+
+test('getQueueMetrics lets live state win when a snapshot carries stale state fields', function () {
+    $service = queueMetricsServiceWith(
+        state: [
+            'depth' => 152361,
+            'pending' => 152361,
+            'scheduled' => 0,
+            'reserved' => 0,
+            'oldest_job_age' => 83880,
+        ],
+        latestMetrics: [
+            'pending' => 0,
+            'oldest_job_age' => 0,
+            'throughput_per_minute' => 12.5,
+        ],
+    );
+
+    $metrics = $service->getQueueMetrics('redis', 'default');
+
+    expect($metrics->pending)->toBe(152361)
+        ->and($metrics->oldestJobAge)->toBe(83880)
+        ->and($metrics->throughputPerMinute)->toBe(12.5);
+});
+
+test('getQueueMetrics falls back to live state alone when no snapshot exists', function () {
+    $service = queueMetricsServiceWith(
+        state: [
+            'depth' => 7,
+            'pending' => 5,
+            'scheduled' => 1,
+            'reserved' => 1,
+            'oldest_job_age' => 30,
+        ],
+        latestMetrics: [],
+    );
+
+    $metrics = $service->getQueueMetrics('redis', 'default');
+
+    expect($metrics->pending)->toBe(5)
+        ->and($metrics->oldestJobAge)->toBe(30)
+        ->and($metrics->throughputPerMinute)->toBe(0.0);
+});


### PR DESCRIPTION
## The bug

`QueueMetricsQueryService::getQueueMetrics()` composes its result as `array_merge($state, $metrics, ...)`, where `$state` is the live queue read and `$metrics` is the recorded snapshot hash. The snapshot writer (`CalculateQueueMetricsAction`) only records `throughput_per_minute`, `avg_duration`, `failure_rate`, `total_processed`, `total_failed`, and `last_processed_at`; it never writes `depth`, `pending`, `scheduled`, `reserved`, or `oldest_job_age`. But the snapshot reader (`getLatestMetrics()`) reconstituted those missing fields as `0`, and the merge let the snapshot overwrite the live state.

So the moment any snapshot hash exists (they are written every collection cycle), `pending` and `oldest_job_age` read `0` no matter what the queue actually holds. Observed in production: an ops dashboard reporting `pending = 0` while the real backlog was 152,361 jobs with the oldest at 23.3 hours. The inverted failure mode is worth noting too: if snapshots stop being written long enough for their TTL to lapse, the fields suddenly become live again, so the bug masks itself during exactly the kind of outage where the numbers matter most.

Separately, `getQueueState()` hardcoded `oldest_job_age`, `scheduled`, and `reserved` to `0` even on the live side (its own comment called it "a simplified version").

## The fix

Three complementary changes:

1. **`getLatestMetrics()` (both repositories) returns only the fields the stored snapshot actually contains.** No more inventing zeros for fields the writer never records. Typing per field is preserved.
2. **`getQueueMetrics()` merges with live state winning** for state-shaped fields: a snapshot is always staler than the queue read made moments earlier, and this also protects against a custom `recordSnapshot()` caller that does store depth fields.
3. **`getQueueState()` (both repositories) reads real numbers from the `QueueInspector`** (`pending`, `reserved`, `scheduled`, and `oldest_job_age` via `QueueDepthData`) instead of `Queue::size()` plus hardcoded zeros. Both repository constructors gained a `QueueInspector` dependency; the contract is already container-bound as a singleton, so construction through the provider is unchanged.

Health scoring is unaffected: `calculateHealthScore()` already treats absent fields as zero, which matches the previous always-zero snapshot values.

## How this has been tested

- New `tests/Unit/Services/QueueMetricsQueryServiceTest.php` (repository contract mocked, no storage backend): live state composes with snapshot performance data; a snapshot carrying stale state fields cannot clobber the live read (this is the exact production failure); no snapshot falls back to live state alone.
- `tests/Feature/Repositories/DatabaseQueueMetricsRepositoryTest.php` updated for the inspector-backed state, plus a new test asserting `getLatestMetrics()` omits never-stored fields. A new `RedisQueueMetricsRepositoryTest.php` mirrors both in the `redis` group against a real Redis.
- Revert check: with `src/` reverted, the four new behavior tests fail; with the fix they pass.
- Full suite `vendor/bin/pest --exclude-group=redis`: **401 passed, 3 skipped, 0 failed**. `vendor/bin/pint` and PHPStan clean.
- The `redis` group was verified against a real Redis in a throwaway Docker container (PHP 8.4 + phpredis + `redis-server`, matching the `test-with-redis` CI job): **16 passed, 0 failed**, including the four new repository tests.

Changelog entry added under Unreleased.
