### PR TITLE
Eliminate the phantom `default` queue and tolerate queues the driver cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-queue-metrics` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Eliminated the phantom `default` queue: queue discovery no longer seeds a hardcoded `'default'` name (the real default comes from the connection configs), and jobs dispatched inside a batch are now recorded under the queue carried by the `JobQueued` event instead of a literal `default`. On drivers with named queues (e.g. SQS) the phantom queue was probed every cycle and could cause downstream consumers to act on a queue no producer writes to.
+- `getQueueDepth()` now tolerates a queue the driver cannot read (for example an SQS queue that does not exist yet): it reports zero depth and logs once per queue per process at info level, instead of letting the driver exception surface as a logged error on every collection cycle.
+
 ## v3.2.1 - Documentation fixes - 2026-07-15
 
 ### Fixed

--- a/src/Listeners/JobQueuedListener.php
+++ b/src/Listeners/JobQueuedListener.php
@@ -25,7 +25,12 @@ final readonly class JobQueuedListener
         }
 
         $connection = $event->connectionName;
-        $queue = $event->job->queue ?? 'default';
+
+        // The event's queue is authoritative: the job instance's own queue
+        // property is null when the destination came from the connection
+        // default or from a bulk push (e.g. every job inside a batch), which
+        // recorded all batched jobs under a literal 'default' queue.
+        $queue = $event->queue ?? $event->job->queue ?? 'default';
 
         // Job can be an object or a string depending on the queue driver
         $job = $event->job;

--- a/src/Services/LaravelQueueInspector.php
+++ b/src/Services/LaravelQueueInspector.php
@@ -59,7 +59,11 @@ final readonly class LaravelQueueInspector implements QueueInspector
     {
         /** @var array<string, array<string, mixed>> $connections */
         $connections = config('queue.connections', []);
-        $discovered = ['default'];
+
+        // No hardcoded seed: the default queue's real name comes from the
+        // connection configs below. Inventing a literal 'default' probed a
+        // queue that does not exist on drivers with named queues (e.g. SQS).
+        $discovered = [];
 
         foreach ($connections as $connection => $config) {
             $queue = $config['queue'] ?? null;

--- a/src/Services/LaravelQueueInspector.php
+++ b/src/Services/LaravelQueueInspector.php
@@ -23,15 +23,58 @@ final readonly class LaravelQueueInspector implements QueueInspector
 
     public function getQueueDepth(string $connection, string $queue): QueueDepthData
     {
-        $queueInstance = $this->queueFactory->connection($connection);
+        try {
+            $queueInstance = $this->queueFactory->connection($connection);
 
-        // Layer 1: Try Laravel 12.19+ native methods (PR #56010)
-        if ($this->hasAllNativeMethods($queueInstance)) {
-            return $this->getDepthNativeApi($queueInstance, $connection, $queue);
+            // Layer 1: Try Laravel 12.19+ native methods (PR #56010)
+            if ($this->hasAllNativeMethods($queueInstance)) {
+                return $this->getDepthNativeApi($queueInstance, $connection, $queue);
+            }
+
+            // Layer 2: Try driver-specific implementations
+            return $this->getDepthViaReflection($queueInstance, $connection, $queue);
+        } catch (\Throwable $e) {
+            $this->reportUnreadableQueue($connection, $queue, $e);
+
+            return new QueueDepthData(
+                connection: $connection,
+                queue: $queue,
+                pendingJobs: 0,
+                reservedJobs: 0,
+                delayedJobs: 0,
+                oldestPendingJobAge: null,
+                oldestDelayedJobAge: null,
+                measuredAt: Carbon::now(),
+            );
+        }
+    }
+
+    /**
+     * Log an unreadable queue once per process instead of every cycle.
+     *
+     * A queue the driver cannot report on (for example an SQS queue that
+     * does not exist yet) is an expected condition. Before this guard the
+     * driver exception escaped to every caller, and the per-queue catch in
+     * the metrics query path logged it as an error on every collection
+     * cycle.
+     */
+    private function reportUnreadableQueue(string $connection, string $queue, \Throwable $e): void
+    {
+        static $reported = [];
+
+        $key = "{$connection}:{$queue}";
+
+        if (isset($reported[$key])) {
+            return;
         }
 
-        // Layer 2: Try driver-specific implementations
-        return $this->getDepthViaReflection($queueInstance, $connection, $queue);
+        $reported[$key] = true;
+
+        logger()->info('Queue depth unavailable; reporting zero until the queue becomes readable', [
+            'connection' => $connection,
+            'queue' => $queue,
+            'error' => $e->getMessage(),
+        ]);
     }
 
     /**

--- a/tests/Unit/Listeners/JobQueuedListenerTest.php
+++ b/tests/Unit/Listeners/JobQueuedListenerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Cbox\LaravelQueueMetrics\Listeners\JobQueuedListener;
+use Cbox\LaravelQueueMetrics\Repositories\Contracts\JobMetricsRepository;
+use Illuminate\Queue\Events\JobQueued;
+
+beforeEach(function () {
+    config(['queue-metrics.persistence.enabled' => true]);
+
+    $this->repository = Mockery::mock(JobMetricsRepository::class);
+    $this->listener = new JobQueuedListener($this->repository);
+});
+
+function queuedEventFor(?string $eventQueue, ?string $jobQueue): JobQueued
+{
+    $job = new stdClass;
+    $job->queue = $jobQueue;
+
+    $event = Mockery::mock(JobQueued::class);
+    $event->connectionName = 'redis';
+    $event->queue = $eventQueue;
+    $event->job = $job;
+
+    return $event;
+}
+
+function expectRecordedQueue(Mockery\MockInterface $repository, string $expectedQueue): void
+{
+    $repository->shouldReceive('recordQueuedAt')->once()->withArgs(
+        function (string $jobClass, string $connection, string $queue, Carbon $queuedAt) use ($expectedQueue): bool {
+            return $queue === $expectedQueue && $connection === 'redis';
+        }
+    );
+}
+
+it('records the queue carried by the event when the job instance has none', function () {
+    expectRecordedQueue($this->repository, 'reports');
+
+    $this->listener->handle(queuedEventFor(eventQueue: 'reports', jobQueue: null));
+});
+
+it('falls back to the job instance queue when the event carries none', function () {
+    expectRecordedQueue($this->repository, 'emails');
+
+    $this->listener->handle(queuedEventFor(eventQueue: null, jobQueue: 'emails'));
+});
+
+it('prefers the event queue over the job instance queue', function () {
+    expectRecordedQueue($this->repository, 'resolved');
+
+    $this->listener->handle(queuedEventFor(eventQueue: 'resolved', jobQueue: 'stale'));
+});
+
+it('falls back to default when neither the event nor the job carries a queue', function () {
+    expectRecordedQueue($this->repository, 'default');
+
+    $this->listener->handle(queuedEventFor(eventQueue: null, jobQueue: null));
+});

--- a/tests/Unit/Services/LaravelQueueInspectorTest.php
+++ b/tests/Unit/Services/LaravelQueueInspectorTest.php
@@ -3,6 +3,34 @@
 declare(strict_types=1);
 
 use Cbox\LaravelQueueMetrics\Services\LaravelQueueInspector;
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Illuminate\Support\Facades\Log;
+
+function inspectorWithBrokenDriver(string $connection): LaravelQueueInspector
+{
+    $broken = new class
+    {
+        public function pendingSize(string $queue): int
+        {
+            throw new RuntimeException('The specified queue does not exist.');
+        }
+
+        public function delayedSize(string $queue): int
+        {
+            throw new RuntimeException('The specified queue does not exist.');
+        }
+
+        public function reservedSize(string $queue): int
+        {
+            throw new RuntimeException('The specified queue does not exist.');
+        }
+    };
+
+    $factory = Mockery::mock(QueueFactory::class);
+    $factory->shouldReceive('connection')->with($connection)->andReturn($broken);
+
+    return new LaravelQueueInspector($factory);
+}
 
 // --- getAllQueues ---
 
@@ -38,4 +66,34 @@ test('getAllQueues gathers queues from connection lists and worker configs', fun
 
     expect($queues)->toContain('primary', 'high', 'low', 'reports', 'exports')
         ->and($queues)->not->toContain('default');
+});
+
+// --- getQueueDepth tolerance ---
+
+test('getQueueDepth reports zeros instead of throwing when the driver cannot read the queue', function () {
+    Log::spy();
+
+    $inspector = inspectorWithBrokenDriver('sqs');
+
+    $depth = $inspector->getQueueDepth('sqs', 'missing-queue-a');
+
+    expect($depth->pendingJobs)->toBe(0)
+        ->and($depth->reservedJobs)->toBe(0)
+        ->and($depth->delayedJobs)->toBe(0)
+        ->and($depth->oldestPendingJobAge)->toBeNull()
+        ->and($depth->isEmpty())->toBeTrue();
+});
+
+test('getQueueDepth logs an unreadable queue once per process, not every cycle', function () {
+    Log::spy();
+
+    $inspector = inspectorWithBrokenDriver('sqs');
+
+    $inspector->getQueueDepth('sqs', 'missing-queue-b');
+    $inspector->getQueueDepth('sqs', 'missing-queue-b');
+    $inspector->getQueueDepth('sqs', 'missing-queue-b');
+
+    Log::shouldHaveReceived('info')
+        ->with('Queue depth unavailable; reporting zero until the queue becomes readable', Mockery::type('array'))
+        ->once();
 });

--- a/tests/Unit/Services/LaravelQueueInspectorTest.php
+++ b/tests/Unit/Services/LaravelQueueInspectorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMetrics\Services\LaravelQueueInspector;
+
+// --- getAllQueues ---
+
+test('getAllQueues does not invent a literal default queue', function () {
+    config()->set('queue.connections', [
+        'sqs' => ['driver' => 'sqs', 'queue' => 'myapp-sqs'],
+    ]);
+    config()->set('queue.workers', []);
+
+    $queues = app(LaravelQueueInspector::class)->getAllQueues();
+
+    expect($queues)->toBe(['myapp-sqs']);
+});
+
+test('getAllQueues still includes default when a connection is configured with it', function () {
+    config()->set('queue.connections', [
+        'redis' => ['driver' => 'redis', 'queue' => 'default'],
+    ]);
+    config()->set('queue.workers', []);
+
+    expect(app(LaravelQueueInspector::class)->getAllQueues())->toContain('default');
+});
+
+test('getAllQueues gathers queues from connection lists and worker configs', function () {
+    config()->set('queue.connections', [
+        'redis' => ['driver' => 'redis', 'queue' => 'primary', 'queues' => ['high', 'low']],
+    ]);
+    config()->set('queue.workers', [
+        ['queue' => 'reports,exports'],
+    ]);
+
+    $queues = app(LaravelQueueInspector::class)->getAllQueues();
+
+    expect($queues)->toContain('primary', 'high', 'low', 'reports', 'exports')
+        ->and($queues)->not->toContain('default');
+});


### PR DESCRIPTION
## The bug

A phantom queue named `default` appears in monitoring and discovery even when no such queue exists, from two independent sources, and probing it produces log spam on drivers with named queues:

1. **Hardcoded discovery seed.** `LaravelQueueInspector::getAllQueues()` seeded its result with the literal string `'default'`. On Redis that is harmless (the connection config names it anyway), but on drivers requiring pre-existing, named queues (e.g. SQS, where the real default queue is something like `myapp-sqs`) there is no queue literally named `default`, so every probe of it fails with `AWS.SimpleQueueService.NonExistentQueue`.
2. **Batched-job attribution.** `JobQueuedListener` read the queue from the job instance (`$event->job->queue`). For jobs dispatched inside a batch, the queue is applied at the bulk-push level and the instance property stays `null`, so every batched job was recorded under a literal `default`. Those recorded keys feed dynamic discovery, so a phantom `default` queue appears and keeps refreshing for as long as batches are dispatched. Observed in production: downstream tooling consuming discovery ran a worker polling a `default` queue that no producer writes to, on every host.
3. **Every-cycle error spam.** When a probed queue does not exist, the driver exception escaped `getQueueDepth()` and was caught per queue in the metrics query path, which logged `Failed to get queue metrics` as an error on every collection cycle (~4x/min).

## The fix

One commit per mechanism:

- `getAllQueues()` starts from an empty list. The real default queue is still discovered from `queue.connections.*.queue` on every driver, including Redis, so nothing changes for Redis users.
- `JobQueuedListener` now prefers the queue carried by the `JobQueued` event (`$event->queue ?? $event->job->queue ?? 'default'`). The event property is authoritative and exists since Laravel 11, so this is safe across the supported matrix.
- `getQueueDepth()` tolerates a queue the driver cannot read: it reports zero depth and logs once per queue per process at info level. Nothing is filtered or dropped, so dynamic discovery is unaffected; an unreadable queue is simply reported empty until it becomes readable (covers not-yet-created queues on any driver, not just SQS).

There is deliberately no name-based filtering anywhere: legitimately discovered dynamic queues (from recorded job metrics) continue to be monitored exactly as before.

## How this has been tested

- New `tests/Unit/Services/LaravelQueueInspectorTest.php`: SQS-style config yields no literal `default`; a connection configured with `default` still includes it; connection `queues` lists and worker configs are still gathered; an unreadable queue reports zeros instead of throwing; the unavailability log fires once across repeated probes, not per cycle.
- New `tests/Unit/Listeners/JobQueuedListenerTest.php`: event queue preferred (the batched-job case), job-instance fallback, and `default` fallback all pinned.
- Revert check: with `src/` reverted, six of the nine new tests fail; the other three pin behavior that must not change (Redis default still monitored, both fallbacks).
- Full suite `vendor/bin/pest --exclude-group=redis`: **405 passed, 3 skipped, 0 failed**. The `redis` group verified against a real Redis in a throwaway Docker container (PHP 8.4 + phpredis + `redis-server`, matching the `test-with-redis` CI job): **12 passed**. Pint and PHPStan clean.

Changelog entries added under Unreleased.

Note: composes with #28, which routes `getQueueState()` through this inspector; once both land, the state read inherits the same tolerance for unreadable queues.
